### PR TITLE
Support video codec profiles

### DIFF
--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -30,7 +30,7 @@
 OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
                                            QWidget *parent) :
     QDialog(parent), mInitialSettings(settings) {
-    setWindowTitle("Output Settings");
+    setWindowTitle(tr("Output Settings"));
 
     mSupportedFormats = {
         FormatCodecs(QList<AVCodecID>() << AV_CODEC_ID_PNG << AV_CODEC_ID_TIFF << AV_CODEC_ID_MJPEG << AV_CODEC_ID_LJPEG,
@@ -74,18 +74,18 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
     setLayout(mMainLayout);
 
     mOutputFormatsLayout = new QHBoxLayout();
-    mOutputFormatsLabel = new QLabel("Format:", this);
+    mOutputFormatsLabel = new QLabel(tr("Format"), this);
     mOutputFormatsComboBox = new QComboBox(this);
     mOutputFormatsLayout->addWidget(mOutputFormatsLabel);
     mOutputFormatsLayout->addWidget(mOutputFormatsComboBox);
 
-    mVideoGroupBox = new QGroupBox("Video", this);
+    mVideoGroupBox = new QGroupBox(tr("Video"), this);
     mVideoGroupBox->setCheckable(true);
     mVideoGroupBox->setChecked(true);
     mVideoSettingsLayout = new TwoColumnLayout();
-    mVideoCodecsLabel = new QLabel("Codec:", this);
-    mPixelFormatsLabel = new QLabel("Pixel format:", this);
-    mBitrateLabel = new QLabel("Bitrate:", this);
+    mVideoCodecsLabel = new QLabel(tr("Codec"), this);
+    mPixelFormatsLabel = new QLabel(tr("Pixel format"), this);
+    mBitrateLabel = new QLabel(tr("Bitrate"), this);
 
     mVideoCodecsComboBox = new QComboBox(this);
     mPixelFormatsComboBox = new QComboBox(this);
@@ -105,14 +105,14 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
     mVideoSettingsLayout->addPair(mBitrateLabel,
                                   mBitrateSpinBox);
 
-    mAudioGroupBox = new QGroupBox("Audio", this);
+    mAudioGroupBox = new QGroupBox(tr("Audio"), this);
     mAudioGroupBox->setCheckable(true);
     mAudioSettingsLayout = new TwoColumnLayout();
-    mAudioCodecsLabel = new QLabel("Codec:", this);
-    mSampleRateLabel = new QLabel("Sample rate:", this);
-    mSampleFormatsLabel = new QLabel("Sample format:", this);
-    mAudioBitrateLabel = new QLabel("Bitrate:", this);
-    mAudioChannelLayoutLabel = new QLabel("Channels:", this);
+    mAudioCodecsLabel = new QLabel(tr("Codec"), this);
+    mSampleRateLabel = new QLabel(tr("Sample rate"), this);
+    mSampleFormatsLabel = new QLabel(tr("Sample format"), this);
+    mAudioBitrateLabel = new QLabel(tr("Bitrate"), this);
+    mAudioChannelLayoutLabel = new QLabel(tr("Channels"), this);
 
     mAudioCodecsComboBox = new QComboBox(this);
     mSampleRateComboBox = new QComboBox(this);
@@ -132,7 +132,7 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
                                   mAudioChannelLayoutsComboBox);
 
     mShowLayout = new QHBoxLayout();
-    mShowLabel = new QLabel("Show all formats and codecs", this);
+    mShowLabel = new QLabel(tr("Show all formats and codecs"), this);
     mShowAllFormatsAndCodecsCheckBox = new QCheckBox(this);
     connect(mShowAllFormatsAndCodecsCheckBox, &QCheckBox::toggled,
             this, &OutputSettingsDialog::setShowAllFormatsAndCodecs);
@@ -142,9 +142,9 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
     mShowLayout->setAlignment(Qt::AlignRight);
 
     mButtonsLayout = new QHBoxLayout();
-    mOkButton = new QPushButton("Ok", this);
-    mCancelButton = new QPushButton("Cancel", this);
-    mResetButton = new QPushButton("Reset", this);
+    mOkButton = new QPushButton(tr("Ok"), this);
+    mCancelButton = new QPushButton(tr("Cancel"), this);
+    mResetButton = new QPushButton(tr("Reset"), this);
     connect(mOkButton, &QPushButton::released,
             this, &OutputSettingsDialog::accept);
     connect(mCancelButton, &QPushButton::released,

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -672,6 +672,9 @@ void OutputSettingsDialog::restoreInitialSettings() {
     } else {
         mBitrateSpinBox->setValue(currentBitrate/1000000.);
     }
+
+    restoreVideoProfileSettings();
+
     const bool noVideoCodecs = mVideoCodecsComboBox->count() == 0;
     mVideoGroupBox->setChecked(mInitialSettings.fVideoEnabled &&
                                !noVideoCodecs);
@@ -743,6 +746,17 @@ void OutputSettingsDialog::restoreInitialSettings() {
     const bool noAudioCodecs = mAudioCodecsComboBox->count() == 0;
     mAudioGroupBox->setChecked(mInitialSettings.fAudioEnabled &&
                                !noAudioCodecs);
+}
+
+void OutputSettingsDialog::restoreVideoProfileSettings()
+{
+    if (mVideoProfileComboBox->count() < 2) { return; }
+    for (int i = 0; i < mVideoProfileComboBox->count(); ++i) {
+        if (mVideoProfileComboBox->itemData(i).toInt() == mInitialSettings.fVideoProfile) {
+            mVideoProfileComboBox->setCurrentIndex(i);
+            break;
+        }
+    }
 }
 
 

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.h
@@ -68,6 +68,7 @@ protected:
     void updateAvailableAudioChannelLayouts();
 
     void restoreInitialSettings();
+    void restoreVideoProfileSettings();
 
     void setShowAllFormatsAndCodecs(const bool bT) {
         if(mShowAllFormatsAndCodecs == bT) return;

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.h
@@ -63,6 +63,7 @@ protected:
     void updateAvailableAudioCodecs();
     void updateAvailableSampleRates();
     void updateAvailableSampleFormats();
+    void updateAvailableVideoProfiles();
     void updateAvailableAudioBitrates();
     void updateAvailableAudioChannelLayouts();
 
@@ -99,6 +100,8 @@ protected:
     QComboBox *mPixelFormatsComboBox = nullptr;
     QLabel *mBitrateLabel = nullptr;
     QDoubleSpinBox *mBitrateSpinBox = nullptr;
+    QLabel *mVideoProfileLabel = nullptr;
+    QComboBox *mVideoProfileComboBox = nullptr;
 
     QGroupBox *mAudioGroupBox = nullptr;
     TwoColumnLayout *mAudioSettingsLayout = nullptr;

--- a/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.cpp
@@ -87,7 +87,9 @@ void OutputSettingsDisplayWidget::setOutputSettings(const OutputSettings &settin
     if(!settings.fVideoCodec) {
         setVideoCodecText("-");
     } else {
-        setVideoCodecText(QString(settings.fVideoCodec->name));
+        setVideoCodecText(QString(settings.fVideoCodec->name),
+                          settings.fVideoCodec,
+                          settings.fVideoProfile);
     }
     const char *pixelFormat = av_get_pix_fmt_name(settings.fVideoPixelFormat);
     if(!pixelFormat) {

--- a/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.h
@@ -75,13 +75,10 @@ private:
             switch (profile) {
             case FF_PROFILE_H264_BASELINE:
                 return tr("Baseline");
-                break;
             case FF_PROFILE_H264_MAIN:
                 return tr("Main");
-                break;
             case FF_PROFILE_H264_HIGH:
                 return tr("High");
-                break;
             default:;
             }
             break;
@@ -89,22 +86,16 @@ private:
             switch (profile) {
             case FF_PROFILE_PRORES_PROXY:
                 return tr("Proxy");
-                break;
             case FF_PROFILE_PRORES_LT:
                 return tr("LT");
-                break;
             case FF_PROFILE_PRORES_STANDARD:
                 return tr("Standard");
-                break;
             case FF_PROFILE_PRORES_HQ:
                 return tr("HQ");
-                break;
             case FF_PROFILE_PRORES_4444:
                 return tr("4444");
-                break;
             case FF_PROFILE_PRORES_XQ:
                 return tr("XQ");
-                break;
             default:;
             }
             break;
@@ -112,13 +103,10 @@ private:
             switch (profile) {
             case FF_PROFILE_AV1_MAIN:
                 return tr("Main");
-                break;
             case FF_PROFILE_AV1_HIGH:
                 return tr("High");
-                break;
             case FF_PROFILE_AV1_PROFESSIONAL:
                 return tr("Professional");
-                break;
             default:;
             }
             break;
@@ -126,16 +114,12 @@ private:
             switch (profile) {
             case FF_PROFILE_VP9_0:
                 return tr("0");
-                break;
             case FF_PROFILE_VP9_1:
                 return tr("1");
-                break;
             case FF_PROFILE_VP9_2:
                 return tr("2");
-                break;
             case FF_PROFILE_VP9_3:
                 return tr("3");
-                break;
             default:;
             }
             break;
@@ -143,13 +127,10 @@ private:
             switch (profile) {
             case FF_PROFILE_MPEG4_SIMPLE:
                 return tr("Simple");
-                break;
             case FF_PROFILE_MPEG4_CORE:
                 return tr("Core");
-                break;
             case FF_PROFILE_MPEG4_MAIN:
                 return tr("Main");
-                break;
             default:;
             }
             break;
@@ -157,16 +138,12 @@ private:
             switch (profile) {
             case FF_PROFILE_VC1_SIMPLE:
                 return tr("Simple");
-                break;
             case FF_PROFILE_VC1_MAIN:
                 return tr("Main");
-                break;
             case FF_PROFILE_VC1_COMPLEX:
                 return tr("Complex");
-                break;
             case FF_PROFILE_VC1_ADVANCED:
                 return tr("Advanced");
-                break;
             default:;
             }
             break;
@@ -174,6 +151,7 @@ private:
         }
         return QString();
     }
+
     void setVideoCodecText(const QString &txt,
                            const AVCodec *codec,
                            int profile)

--- a/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdisplaywidget.h
@@ -66,6 +66,126 @@ private:
         mVideoCodecLabel->setText("<b>Video codec:</b><br>" + txt);
     }
 
+    const QString getVideoProfileName(const AVCodec *codec,
+                                      int profile)
+    {
+        if (profile < 0 || !codec) { return QString(); }
+        switch (codec->id) {
+        case AV_CODEC_ID_H264:
+            switch (profile) {
+            case FF_PROFILE_H264_BASELINE:
+                return tr("Baseline");
+                break;
+            case FF_PROFILE_H264_MAIN:
+                return tr("Main");
+                break;
+            case FF_PROFILE_H264_HIGH:
+                return tr("High");
+                break;
+            default:;
+            }
+            break;
+        case AV_CODEC_ID_PRORES:
+            switch (profile) {
+            case FF_PROFILE_PRORES_PROXY:
+                return tr("Proxy");
+                break;
+            case FF_PROFILE_PRORES_LT:
+                return tr("LT");
+                break;
+            case FF_PROFILE_PRORES_STANDARD:
+                return tr("Standard");
+                break;
+            case FF_PROFILE_PRORES_HQ:
+                return tr("HQ");
+                break;
+            case FF_PROFILE_PRORES_4444:
+                return tr("4444");
+                break;
+            case FF_PROFILE_PRORES_XQ:
+                return tr("XQ");
+                break;
+            default:;
+            }
+            break;
+        case AV_CODEC_ID_AV1:
+            switch (profile) {
+            case FF_PROFILE_AV1_MAIN:
+                return tr("Main");
+                break;
+            case FF_PROFILE_AV1_HIGH:
+                return tr("High");
+                break;
+            case FF_PROFILE_AV1_PROFESSIONAL:
+                return tr("Professional");
+                break;
+            default:;
+            }
+            break;
+        case AV_CODEC_ID_VP9:
+            switch (profile) {
+            case FF_PROFILE_VP9_0:
+                return tr("0");
+                break;
+            case FF_PROFILE_VP9_1:
+                return tr("1");
+                break;
+            case FF_PROFILE_VP9_2:
+                return tr("2");
+                break;
+            case FF_PROFILE_VP9_3:
+                return tr("3");
+                break;
+            default:;
+            }
+            break;
+        case AV_CODEC_ID_MPEG4:
+            switch (profile) {
+            case FF_PROFILE_MPEG4_SIMPLE:
+                return tr("Simple");
+                break;
+            case FF_PROFILE_MPEG4_CORE:
+                return tr("Core");
+                break;
+            case FF_PROFILE_MPEG4_MAIN:
+                return tr("Main");
+                break;
+            default:;
+            }
+            break;
+        case AV_CODEC_ID_VC1:
+            switch (profile) {
+            case FF_PROFILE_VC1_SIMPLE:
+                return tr("Simple");
+                break;
+            case FF_PROFILE_VC1_MAIN:
+                return tr("Main");
+                break;
+            case FF_PROFILE_VC1_COMPLEX:
+                return tr("Complex");
+                break;
+            case FF_PROFILE_VC1_ADVANCED:
+                return tr("Advanced");
+                break;
+            default:;
+            }
+            break;
+        default:;
+        }
+        return QString();
+    }
+    void setVideoCodecText(const QString &txt,
+                           const AVCodec *codec,
+                           int profile)
+    {
+        QString label = "<b>%1:</b><br>%2";
+        QString profileName = getVideoProfileName(codec, profile);
+        if (!profileName.isEmpty()) {
+            label.append(QString(" (%1)").arg(profileName));
+        }
+        mVideoCodecLabel->setText(label.arg(tr("Video codec"), txt));
+    }
+
     void setPixelFormatText(const QString &txt) {
         mVideoPixelFormatLabel->setText("<b>Pixel format:</b><br>" + txt);
     }

--- a/src/core/ReadWrite/evformat.h
+++ b/src/core/ReadWrite/evformat.h
@@ -38,6 +38,7 @@ namespace EvFormat {
         colorizeInfluence = 23,
         transformEffects = 24,
         transformEffects2 = 25,
+        codecProfile = 26,
 
         nextVersion
     };

--- a/src/core/outputsettings.cpp
+++ b/src/core/outputsettings.cpp
@@ -253,7 +253,8 @@ void OutputSettingsProfile::load(const QString &path)
                                                          .toUtf8()
                                                          .data());
             mSettings.fVideoBitrate = profile.value(QString::fromUtf8("video_bitrate")).toInt();
-            mSettings.fVideoProfile = profile.value(QString::fromUtf8("video_profile")).toInt();
+            mSettings.fVideoProfile = profile.value(QString::fromUtf8("video_profile"),
+                                                    FF_PROFILE_UNKNOWN).toInt();
         }
         mSettings.fAudioEnabled = profileAudioEnabled;
         if (mSettings.fAudioEnabled) {

--- a/src/core/outputsettings.h
+++ b/src/core/outputsettings.h
@@ -55,6 +55,7 @@ struct CORE_EXPORT OutputSettings
     const AVCodec *fVideoCodec = nullptr;
     AVPixelFormat fVideoPixelFormat = AV_PIX_FMT_NONE;
     int fVideoBitrate = 0;
+    int fVideoProfile = FF_PROFILE_UNKNOWN;
 
     bool fAudioEnabled = false;
     const AVCodec *fAudioCodec = nullptr;

--- a/src/core/videoencoder.cpp
+++ b/src/core/videoencoder.cpp
@@ -65,6 +65,75 @@ void VideoEncoder::allAudioProvided() {
     if(getState() < eTaskState::qued || getState() > eTaskState::processing) queTask();
 }
 
+bool VideoEncoder::isValidProfile(const AVCodec *codec,
+                                  int profile)
+{
+    if (profile < 0 || !codec) { return false; }
+    switch (codec->id) {
+    case AV_CODEC_ID_H264:
+        switch (profile) {
+        case FF_PROFILE_H264_BASELINE:
+        case FF_PROFILE_H264_MAIN:
+        case FF_PROFILE_H264_HIGH:
+            return true;
+        default:;
+        }
+        break;
+    case AV_CODEC_ID_PRORES:
+        switch (profile) {
+        case FF_PROFILE_PRORES_PROXY:
+        case FF_PROFILE_PRORES_LT:
+        case FF_PROFILE_PRORES_STANDARD:
+        case FF_PROFILE_PRORES_HQ:
+        case FF_PROFILE_PRORES_4444:
+        case FF_PROFILE_PRORES_XQ:
+            return true;
+        default:;
+        }
+        break;
+    case AV_CODEC_ID_AV1:
+        switch (profile) {
+        case FF_PROFILE_AV1_MAIN:
+        case FF_PROFILE_AV1_HIGH:
+        case FF_PROFILE_AV1_PROFESSIONAL:
+            return true;
+        default:;
+        }
+        break;
+    case AV_CODEC_ID_VP9:
+        switch (profile) {
+        case FF_PROFILE_VP9_0:
+        case FF_PROFILE_VP9_1:
+        case FF_PROFILE_VP9_2:
+        case FF_PROFILE_VP9_3:
+            return true;
+        default:;
+        }
+        break;
+    case AV_CODEC_ID_MPEG4:
+        switch (profile) {
+        case FF_PROFILE_MPEG4_SIMPLE:
+        case FF_PROFILE_MPEG4_CORE:
+        case FF_PROFILE_MPEG4_MAIN:
+            return true;
+        default:;
+        }
+        break;
+    case AV_CODEC_ID_VC1:
+        switch (profile) {
+        case FF_PROFILE_VC1_SIMPLE:
+        case FF_PROFILE_VC1_MAIN:
+        case FF_PROFILE_VC1_COMPLEX:
+        case FF_PROFILE_VC1_ADVANCED:
+            return true;
+        default:;
+        }
+        break;
+    default:;
+    }
+    return false;
+}
+
 static AVFrame *allocPicture(enum AVPixelFormat pix_fmt,
                              const int width, const int height) {
     AVFrame * const picture = av_frame_alloc();
@@ -132,8 +201,8 @@ static void addVideoStream(OutputStream * const ost,
     ost->fStream->time_base = renSettings.fTimeBase;
     c->time_base       = ost->fStream->time_base;
 
-    // set video codec profile (if any)
-    if (outSettings.fVideoProfile >= 0) {
+    if (VideoEncoder::isValidProfile(codec,
+                                     outSettings.fVideoProfile)) {
         c->profile = outSettings.fVideoProfile;
     }
 

--- a/src/core/videoencoder.cpp
+++ b/src/core/videoencoder.cpp
@@ -132,6 +132,11 @@ static void addVideoStream(OutputStream * const ost,
     ost->fStream->time_base = renSettings.fTimeBase;
     c->time_base       = ost->fStream->time_base;
 
+    // set video codec profile (if any)
+    if (outSettings.fVideoProfile >= 0) {
+        c->profile = outSettings.fVideoProfile;
+    }
+
     c->gop_size      = 12; /* emit one intra frame every twelve frames at most */
     c->pix_fmt       = outSettings.fVideoPixelFormat;//RGBA;
     if(c->codec_id == AV_CODEC_ID_MPEG2VIDEO) {

--- a/src/core/videoencoder.h
+++ b/src/core/videoencoder.h
@@ -213,6 +213,8 @@ public:
 
     static VideoEncoder *sInstance;
 
+    static bool isValidProfile(const AVCodec *codec, int profile);
+
     static void sInterruptEncoding();
     static bool sStartEncoding(RenderInstanceSettings *settings);
     static void sAddCacheContainerToEncoder(const stdsptr<SceneFrameContainer> &cont);


### PR DESCRIPTION
This PR adds support for video codec profiles (encode).

The following codecs now support profiles:

- H264 _(baseline/main/high)_
- ProRes _(proxy/lt/standard/hq/4444/xq)_
- AV1 _(main/high/professional)_
- VP9 _(0/1/2/3)_
- MPEG4 _(simple/core/main)_
- VC1 _(simple/main/complex/advanced)_

Support for more codecs can be added later.

**WARNING!** This commit bumps the evformat (26). Project files saved with this version or later will not be compatible with earlier versions of Friction (or enve).

Fix #129 

