### PR TITLE
Only show usable animators in graph

### DIFF
--- a/src/app/GUI/graphboxeslist.cpp
+++ b/src/app/GUI/graphboxeslist.cpp
@@ -472,7 +472,9 @@ void KeysView::graphSetOnlySelectedVisible(const bool selectedOnly) {
 }
 
 bool KeysView::graphValidateVisible(GraphAnimator* const animator) {
-    if(graph_mOnlySelectedVisible){
+    // https://github.com/friction2d/friction/issues/176
+    if (!animator->prp_isParentBoxGraphSelected()) { return false; }
+    if (graph_mOnlySelectedVisible) {
         return animator->prp_isParentBoxSelected();
     }
     return true;

--- a/src/core/Animators/eboxorsound.cpp
+++ b/src/core/Animators/eboxorsound.cpp
@@ -381,6 +381,12 @@ void eBoxOrSound::setSelected(const bool select) {
     emit selectionChanged(select);
 }
 
+void eBoxOrSound::setGraphSelected(const bool select)
+{
+    if (mGraphSelected == select) { return; }
+    mGraphSelected = select;
+}
+
 void eBoxOrSound::select() {
     setSelected(true);
 }

--- a/src/core/Animators/eboxorsound.h
+++ b/src/core/Animators/eboxorsound.h
@@ -111,9 +111,11 @@ public:
     bool isFrameFVisibleAndInDurationRect(const qreal relFrame) const;
 
     void setSelected(const bool select);
+    void setGraphSelected(const bool select);
     void select();
     void deselect();
     bool isSelected() const { return mSelected; }
+    bool isGraphSelected() const { return mGraphSelected; }
     void selectionChangeTriggered(const bool shiftPressed);
 
     void hide();
@@ -146,6 +148,7 @@ signals:
     void lockedChanged(bool);
 private:
     bool mSelected = false;
+    bool mGraphSelected = false;
     bool mVisible = true;
     bool mLocked = false;
     int mZListIndex = 0;

--- a/src/core/Properties/property.cpp
+++ b/src/core/Properties/property.cpp
@@ -362,6 +362,13 @@ bool Property::prp_isParentBoxSelected() const {
     return false;
 }
 
+bool Property::prp_isParentBoxGraphSelected() const
+{
+    const auto pBox = getFirstAncestor<eBoxOrSound>();
+    if (pBox) { return pBox->isGraphSelected(); }
+    return false;
+}
+
 #include "canvas.h"
 void Property::prp_selectionChangeTriggered(const bool shiftPressed) {
     if(!mParentScene) return;

--- a/src/core/Properties/property.h
+++ b/src/core/Properties/property.h
@@ -249,6 +249,7 @@ public:
     }
 
     bool prp_isParentBoxSelected() const;
+    bool prp_isParentBoxGraphSelected() const;
 
     bool prp_drawsOnCanvas() const
     { return mDrawOnCanvas; }

--- a/src/core/canvasselectedboxesactions.cpp
+++ b/src/core/canvasselectedboxesactions.cpp
@@ -439,6 +439,7 @@ void Canvas::addBoxToSelection(BoundingBox * const box)
     });
 
     box->setSelected(true);
+    box->setGraphSelected(true);
     schedulePivotUpdate();
 
     sortSelectedBoxesDesc();
@@ -455,9 +456,10 @@ void Canvas::addBoxToSelection(BoundingBox * const box)
 }
 
 void Canvas::removeBoxFromSelection(BoundingBox * const box) {
-    if(!box->isSelected()) return;
+    if (!box->isSelected()) { return; }
     mSelectedBoxes.removeObj(box);
     box->setSelected(false);
+    box->setGraphSelected(false);
     schedulePivotUpdate();
     //if(mCurrentMode == CanvasMode::paint) updatePaintBox();
     if (mSelectedBoxes.isEmpty()) { setCurrentBox(nullptr); }


### PR DESCRIPTION
This is a proposed solution for issue #176.

Introduces a new "isGraphSelected" function for boxes and "prp_isParentBoxGraphSelected" for properties. This function is used by the graph to figure out which animators are usable or not, the state is controlled by the canvas. if "isGraphSelected" is false then the box should be considered removed and the animator connected to the box should be ignored, we do not remove it since that breaks undo.

Binaries: https://sourceforge.net/projects/friction/files/0.9.6-629e18e8/

Fix #176 