### PR TITLE
Export SVG: add compatibility checks

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1803,9 +1803,19 @@ void MainWindow::saveBackup()
     }
 }
 
+const QString MainWindow::checkBeforeExportSVG()
+{
+    QStringList result;
+    for (const auto& scene : mDocument.fScenes) {
+        const auto warnings = scene->checkForUnsupportedSVG();
+        if (!warnings.isEmpty()) { result.append(warnings); }
+    }
+    return result.join("");
+}
+
 void MainWindow::exportSVG()
 {
-    const auto dialog = new ExportSvgDialog(this);
+    const auto dialog = new ExportSvgDialog(this, checkBeforeExportSVG());
     dialog->show();
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 }

--- a/src/app/GUI/mainwindow.h
+++ b/src/app/GUI/mainwindow.h
@@ -179,6 +179,7 @@ public:
                   const bool setPath = true);
     void saveFileAs(const bool setPath = true);
     void saveBackup();
+    const QString checkBeforeExportSVG();
     void exportSVG();
     void updateLastOpenDir(const QString &path);
     void updateLastSaveDir(const QString &path);

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -314,6 +314,25 @@ bool BoundingBox::hasBlendEffects() const {
     return mBlendEffectCollection->ca_hasChildren();
 }
 
+const QStringList BoundingBox::checkRasterEffectsForSVGSupport()
+{
+    QStringList result;
+    const int totalEffects = mRasterEffectsAnimators->ca_getNumberOfChildren();
+    for (int i = 0; i < totalEffects; ++i) {
+        const auto effect = enve_cast<RasterEffect*>(mRasterEffectsAnimators->getChild(i));
+        if (!effect) { continue; }
+        if (!effect->isVisible()) { continue; }
+        bool isSafeForSVG = false;
+        if (const auto blur = enve_cast<BlurEffect*>(effect)) {
+            isSafeForSVG = true;
+        } else if (const auto shadow = enve_cast<ShadowEffect*>(effect)) {
+            isSafeForSVG = true;
+        }
+        if (!isSafeForSVG) { result.append(effect->prp_getName()); }
+    }
+    return result;
+}
+
 void BoundingBox::applyTransformEffects(
         const qreal relFrame,
         qreal& pivotX, qreal& pivotY,

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -419,6 +419,8 @@ public:
     bool hasEnabledBlendEffects() const
     { return blendEffectsEnabled() && hasBlendEffects(); }
 
+    const QStringList checkRasterEffectsForSVGSupport();
+
     void applyTransformEffects(const qreal relFrame,
                                qreal& pivotX, qreal& pivotY,
                                qreal& posX, qreal& posY,

--- a/src/core/Boxes/textbox.h
+++ b/src/core/Boxes/textbox.h
@@ -71,6 +71,8 @@ public:
 
     void openTextEditor(QWidget* dialogParent);
 
+    bool hasTextEffects() const { return mTextEffects->hasEffects(); };
+
     void setCurrentValue(const QString &text);
 
     void saveSVG(SvgExporter& doc, DomEleTask* const task) const;

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -217,6 +217,9 @@ public:
     void removeBoxFromSelection(BoundingBox* const box);
     void clearBoxesSelection();
     void clearBoxesSelectionList();
+    const QString checkForUnsupportedBoxSVG(BoundingBox* const box);
+    const QString checkForUnsupportedBoxesSVG(const QList<BoundingBox*> boxes);
+    const QString checkForUnsupportedSVG();
 
     void addPointToSelection(MovablePoint * const point);
     void removePointFromSelection(MovablePoint * const point);

--- a/src/ui/dialogs/exportsvgdialog.cpp
+++ b/src/ui/dialogs/exportsvgdialog.cpp
@@ -36,8 +36,10 @@
 #include <QPushButton>
 #include <QMenuBar>
 #include <QDesktopServices>
+#include <QPlainTextEdit>
 
-ExportSvgDialog::ExportSvgDialog(QWidget* const parent)
+ExportSvgDialog::ExportSvgDialog(QWidget* const parent,
+                                 const QString &warnings)
     : QDialog(parent)
 {
     setWindowTitle(tr("Export SVG"));
@@ -86,7 +88,7 @@ ExportSvgDialog::ExportSvgDialog(QWidget* const parent)
 
     // image options
     QLabel *mImageFormatLabel = new QLabel(tr("Raster Format:"), this);
-    mImageFormatLabel->setToolTip(tr("Image format for raster elements contained in the scene"));
+    mImageFormatLabel->setToolTip(tr("Image format used for raster elements (images/videos) contained in the scene"));
     mImageFormat = new QComboBox(this);
     mImageFormat->setToolTip(mImageFormatLabel->toolTip());
     mImageFormat->addItem(tr("PNG"));
@@ -124,16 +126,16 @@ ExportSvgDialog::ExportSvgDialog(QWidget* const parent)
     QHBoxLayout *mImageOptionsLayout = new QHBoxLayout(mImageOptions);
     mImageOptionsLayout->setContentsMargins(0, 0, 0, 0);
 
-    mImageOptionsLayout->addWidget(mImageFormatLabel);
     mImageOptionsLayout->addWidget(mImageFormat);
     mImageOptionsLayout->addWidget(mImageQuality);
+    twoColLayout->addPair(mImageFormatLabel, mImageOptions);
 
     // settings layout
     settingsLayout->addLayout(twoColLayout);
-    settingsLayout->addWidget(mImageOptions);
     settingsLayout->addWidget(mBackground);
     settingsLayout->addWidget(mFixedSize);
     settingsLayout->addWidget(mLoop);
+    settingsLayout->addStretch();
 
     connect(mFirstFrame, qOverload<int>(&QSpinBox::valueChanged),
             mLastFrame, &QSpinBox::setMinimum);
@@ -168,9 +170,21 @@ ExportSvgDialog::ExportSvgDialog(QWidget* const parent)
 
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
+    if (!warnings.isEmpty()) {
+        const auto warnWidget = new QPlainTextEdit(this);
+        warnWidget->setSizePolicy(QSizePolicy::Expanding,
+                                  QSizePolicy::Expanding);
+        warnWidget->setMinimumHeight(100);
+        warnWidget->setMinimumWidth(500);
+        warnWidget->setReadOnly(true);
+        warnWidget->setPlainText(warnings);
+        settingsLayout->addWidget(warnWidget);
+    }
+
     settingsLayout->addWidget(buttons, 0, Qt::AlignBottom);
 
     mPreviewButton = new QPushButton(tr("Preview"), this);
+    mPreviewButton->setIcon(QIcon::fromTheme("seq_preview"));
     mPreviewButton->setObjectName("SVGPreviewButton");
     buttons->addButton(mPreviewButton, QDialogButtonBox::ActionRole);
     connect(mPreviewButton, &QPushButton::released, this, [this]() {
@@ -195,11 +209,12 @@ ExportSvgDialog::ExportSvgDialog(QWidget* const parent)
 
     const auto settingsWidget = new QWidget(this);
     settingsWidget->setLayout(settingsLayout);
-    settingsWidget->setSizePolicy(QSizePolicy::Fixed,
+    settingsWidget->setSizePolicy(QSizePolicy::Expanding,
                                   QSizePolicy::MinimumExpanding);
 
-    const auto mainLayout = new QHBoxLayout(this);
+    const auto mainLayout = new QVBoxLayout(this);
     mainLayout->addWidget(settingsWidget);
+
     setLayout(mainLayout);
 }
 

--- a/src/ui/dialogs/exportsvgdialog.h
+++ b/src/ui/dialogs/exportsvgdialog.h
@@ -36,7 +36,8 @@ class ComplexTask;
 class UI_EXPORT ExportSvgDialog : public QDialog
 {
 public:
-    ExportSvgDialog(QWidget* const parent = nullptr);
+    ExportSvgDialog(QWidget* const parent = nullptr,
+                    const QString &warnings = QString());
 
 private:
     ComplexTask* exportTo(const QString& file,


### PR DESCRIPTION
The export SVG dialog will now show warnings/notes etc if some part of the project is not compatible with SVG+SMIL.

![friction-svg-export-warning](https://github.com/friction2d/friction/assets/34516798/7806e6e0-16c6-4c3e-81ec-d8707adcd4c3)

*If no warning the dialog will of course not include the warning field ;)*

Fix #174 