### PR TITLE
SVG: support quick preview

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -510,6 +510,12 @@ void MainWindow::setupMenuBar()
                                                   tr("Save Backup", "MenuBar_File"),
                                                   this, &MainWindow::saveBackup);
 
+    const auto previewSvgAct = mFileMenu->addAction(QIcon::fromTheme("seq_preview"),
+                                                    tr("Preview SVG", "MenuBar_File"),
+                                                    this,[this]{ exportSVG(true); },
+                                                    QKeySequence(AppSupport::getSettings("shortcuts",
+                                                                                         "previewSVG",
+                                                                                         "Ctrl+F12").toString()));
     const auto exportSvgAct = mFileMenu->addAction(QIcon::fromTheme("seq_preview"),
                                                    tr("Export SVG", "MenuBar_File"),
                                                    this, &MainWindow::exportSVG,
@@ -519,7 +525,7 @@ void MainWindow::setupMenuBar()
     saveToolBtn->setDefaultAction(mSaveAct);
     saveToolMenu->addAction(saveAsAct);
     saveToolMenu->addAction(saveBackAct);
-    saveToolMenu->addAction(exportSvgAct);
+    //saveToolMenu->addAction(exportSvgAct);
     saveToolMenu->addSeparator();
 
     mFileMenu->addSeparator();
@@ -1146,6 +1152,7 @@ void MainWindow::setupMenuBar()
                         tr("Render"),
                         this, &MainWindow::openRendererWindow);
 
+    mToolbar->addAction(previewSvgAct);
     mToolbar->addAction(exportSvgAct);
 
     setMenuBar(mMenuBar);
@@ -1813,11 +1820,16 @@ const QString MainWindow::checkBeforeExportSVG()
     return result.join("");
 }
 
-void MainWindow::exportSVG()
+void MainWindow::exportSVG(const bool &preview)
 {
-    const auto dialog = new ExportSvgDialog(this, checkBeforeExportSVG());
-    dialog->show();
+    const auto dialog = new ExportSvgDialog(this,
+                                            preview ? QString() : checkBeforeExportSVG());
     dialog->setAttribute(Qt::WA_DeleteOnClose);
+    if (!preview) {
+        dialog->show();
+    } else {
+        dialog->showPreview(true /* close when done */);
+    }
 }
 
 void MainWindow::updateLastOpenDir(const QString &path)

--- a/src/app/GUI/mainwindow.h
+++ b/src/app/GUI/mainwindow.h
@@ -180,7 +180,7 @@ public:
     void saveFileAs(const bool setPath = true);
     void saveBackup();
     const QString checkBeforeExportSVG();
-    void exportSVG();
+    void exportSVG(const bool &preview = false);
     void updateLastOpenDir(const QString &path);
     void updateLastSaveDir(const QString &path);
     const QString getLastOpenDir();

--- a/src/ui/dialogs/exportsvgdialog.h
+++ b/src/ui/dialogs/exportsvgdialog.h
@@ -38,6 +38,7 @@ class UI_EXPORT ExportSvgDialog : public QDialog
 public:
     ExportSvgDialog(QWidget* const parent = nullptr,
                     const QString &warnings = QString());
+    void showPreview(const bool &closeWhenDone = false);
 
 private:
     ComplexTask* exportTo(const QString& file,


### PR DESCRIPTION
Added 'Preview SVG' action to toolbar (and file menu) with shortcut 'Ctrl+F12'.
![friction-toolbar-096](https://github.com/friction2d/friction/assets/34516798/890041cc-08a4-4a9b-bf28-65b7819770bd)


Also (re)store export dialog check boxes state (background/fixed/loop).

*I know we are in a feature freeze, but ... I was doing a lot of previews on a project yesterday and the UX is bad! Too many clicks.*