### PR TITLE
ShaderEffects refactor v1

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -617,6 +617,7 @@ set(
     swt_abstraction.h
     swt_rulescollection.h
     texteffect.h
+    threadsafeqjsengine.h
     transformvalues.h
     undoredo.h
     exceptions.h

--- a/src/core/ShaderEffects/shadereffect.cpp
+++ b/src/core/ShaderEffects/shadereffect.cpp
@@ -56,8 +56,12 @@ stdsptr<RasterEffectCaller> ShaderEffect::getEffectCaller(const qreal relFrame,
     Q_UNUSED(data)
     std::unique_ptr<ShaderEffectJS> engineUPtr;
     takeJSEngine(engineUPtr);
-    const auto effect = enve::make_shared<ShaderEffectCaller>(std::move(engineUPtr), *mProgram);
-    effect->calc(this, relFrame, resolution, influence);
+    const auto effect = enve::make_shared<ShaderEffectCaller>(std::move(engineUPtr),
+                                                              *mProgram,
+                                                              this,
+                                                              relFrame,
+                                                              resolution,
+                                                              influence);
     return effect;
 }
 

--- a/src/core/ShaderEffects/shadereffect.cpp
+++ b/src/core/ShaderEffects/shadereffect.cpp
@@ -48,34 +48,16 @@ void ShaderEffect::writeIdentifierXEV(QDomElement& ele) const {
     mCreator->writeIdentifierXEV(ele);
 }
 
-stdsptr<RasterEffectCaller> ShaderEffect::getEffectCaller(
-        const qreal relFrame, const qreal resolution,
-        const qreal influence, BoxRenderData * const data) const {
+stdsptr<RasterEffectCaller> ShaderEffect::getEffectCaller(const qreal relFrame,
+                                                          const qreal resolution,
+                                                          const qreal influence,
+                                                          BoxRenderData * const data) const
+{
     Q_UNUSED(data)
     std::unique_ptr<ShaderEffectJS> engineUPtr;
     takeJSEngine(engineUPtr);
-    ShaderEffectJS& engine = *engineUPtr;
-    const auto effect = enve::make_shared<ShaderEffectCaller>(
-                            std::move(engineUPtr), *mProgram);
-
-    QJSValueList setterArgs;
-    UniformSpecifiers& uniSpecs = effect->mUniformSpecifiers;
-    const int argsCount = mProgram->fPropUniLocs.count();
-    for(int i = 0; i < argsCount; i++) {
-        const GLint loc = mProgram->fPropUniLocs.at(i);
-        const auto prop = ca_getChildAt(i);
-        const auto& uniformC = mProgram->fPropUniCreators.at(i);
-        uniformC->create(engine, loc, prop, relFrame,
-                         resolution, influence,
-                         setterArgs, uniSpecs);
-    }
-    engine.setValues(setterArgs);
-    const int valsCount = mProgram->fValueHandlers.count();
-    for(int i = 0; i < valsCount; i++) {
-        const GLint loc = mProgram->fValueLocs.at(i);
-        const auto& value = mProgram->fValueHandlers.at(i);
-        uniSpecs << value->create(loc, &engine.getGlValueGetter(i));
-    }
+    const auto effect = enve::make_shared<ShaderEffectCaller>(std::move(engineUPtr), *mProgram);
+    effect->calc(this, relFrame, resolution, influence);
     return effect;
 }
 

--- a/src/core/ShaderEffects/shadereffectcaller.cpp
+++ b/src/core/ShaderEffects/shadereffectcaller.cpp
@@ -63,7 +63,7 @@ void ShaderEffectCaller::calc(const ShaderEffect *pEff,
                               const qreal influence)
 {
     if (!pEff) { return; }
-    QJSValueList setterArgs;
+    mEngine->clearSetters();
     UniformSpecifiers& uniSpecs = mUniformSpecifiers;
     const int argsCount = mProgram.fPropUniLocs.count();
     for (int i = 0; i < argsCount; i++) {
@@ -72,9 +72,9 @@ void ShaderEffectCaller::calc(const ShaderEffect *pEff,
         const auto& uniformC = mProgram.fPropUniCreators.at(i);
         uniformC->create(getJSEngine(), loc, prop, relFrame,
                          resolution, influence,
-                         setterArgs, uniSpecs);
+                         getJSEngine().getSetters(), uniSpecs);
     }
-    mEngine->setValues(setterArgs);
+    mEngine->updateValues();
     const int valsCount = mProgram.fValueHandlers.count();
     for (int i = 0; i < valsCount; i++) {
         const GLint loc = mProgram.fValueLocs.at(i);

--- a/src/core/ShaderEffects/shadereffectcaller.cpp
+++ b/src/core/ShaderEffects/shadereffectcaller.cpp
@@ -79,7 +79,7 @@ void ShaderEffectCaller::calc(const ShaderEffect *pEff,
     for (int i = 0; i < valsCount; i++) {
         const GLint loc = mProgram.fValueLocs.at(i);
         const auto& value = mProgram.fValueHandlers.at(i);
-        uniSpecs << value->create(loc, &getJSEngine().getGlValueGetter(i));
+        uniSpecs << value->create(loc, getJSEngine(), i);
     }
 }
 

--- a/src/core/ShaderEffects/shadereffectcaller.cpp
+++ b/src/core/ShaderEffects/shadereffectcaller.cpp
@@ -24,23 +24,28 @@
 // Fork of enve - Copyright (C) 2016-2020 Maurycy Liebner
 
 #include "shadereffectcaller.h"
-
 #include "shadereffectprogram.h"
 
 ShaderEffectCaller::ShaderEffectCaller(std::unique_ptr<ShaderEffectJS>&& engine,
-                                       const ShaderEffectProgram &program) :
-    RasterEffectCaller(HardwareSupport::gpuOnly, false, QMargins()),
-    mEngine(std::move(engine)), mProgramId(program.fId), mProgram(program) {
+                                       const ShaderEffectProgram &program)
+    : RasterEffectCaller(HardwareSupport::gpuOnly,
+                         false,
+                         QMargins())
+    , mEngine(std::move(engine))
+    , mProgramId(program.fId)
+    , mProgram(program)
+{
     Q_ASSERT(mEngine.get());
 }
 
-ShaderEffectCaller::~ShaderEffectCaller() {
+ShaderEffectCaller::~ShaderEffectCaller()
+{
     mProgram.fEngines.push_back(std::move(mEngine));
 }
 
 void ShaderEffectCaller::processGpu(QGL33 * const gl,
-                                    GpuRenderTools &renderTools) {
-
+                                    GpuRenderTools &renderTools)
+{
     renderTools.switchToOpenGL(gl);
 
     renderTools.requestTargetFbo().bind(gl);
@@ -70,9 +75,13 @@ void ShaderEffectCaller::calc(const ShaderEffect *pEff,
         const GLint loc = mProgram.fPropUniLocs.at(i);
         const auto prop = pEff->ca_getChildAt(i);
         const auto& uniformC = mProgram.fPropUniCreators.at(i);
-        uniformC->create(getJSEngine(), loc, prop, relFrame,
-                         resolution, influence,
-                         getJSEngine().getSetters(), uniSpecs);
+        uniformC->create(getJSEngine(),
+                         loc,
+                         prop,
+                         relFrame,
+                         resolution,
+                         influence,
+                         uniSpecs);
     }
     mEngine->updateValues();
     const int valsCount = mProgram.fValueHandlers.count();
@@ -83,13 +92,15 @@ void ShaderEffectCaller::calc(const ShaderEffect *pEff,
     }
 }
 
-QMargins ShaderEffectCaller::getMargin(const SkIRect &srcRect) {
+QMargins ShaderEffectCaller::getMargin(const SkIRect &srcRect)
+{
     mEngine->setSceneRect(srcRect);
     mEngine->evaluate();
     return mEngine->getMargins();
 }
 
-void ShaderEffectCaller::setupProgram(QGL33 * const gl) {
+void ShaderEffectCaller::setupProgram(QGL33 * const gl)
+{
     gl->glUseProgram(mProgramId);
-    for(const auto& uni : mUniformSpecifiers) uni(gl);
+    for (const auto& uni : mUniformSpecifiers) { uni(gl); }
 }

--- a/src/core/ShaderEffects/shadereffectcaller.cpp
+++ b/src/core/ShaderEffects/shadereffectcaller.cpp
@@ -27,7 +27,11 @@
 #include "shadereffectprogram.h"
 
 ShaderEffectCaller::ShaderEffectCaller(std::unique_ptr<ShaderEffectJS>&& engine,
-                                       const ShaderEffectProgram &program)
+                                       const ShaderEffectProgram &program,
+                                       const ShaderEffect *parentEffect,
+                                       const qreal &relFrame,
+                                       const qreal &resolution,
+                                       const qreal &influence)
     : RasterEffectCaller(HardwareSupport::gpuOnly,
                          false,
                          QMargins())
@@ -36,6 +40,10 @@ ShaderEffectCaller::ShaderEffectCaller(std::unique_ptr<ShaderEffectJS>&& engine,
     , mProgram(program)
 {
     Q_ASSERT(mEngine.get());
+    calc(parentEffect,
+         relFrame,
+         resolution,
+         influence);
 }
 
 ShaderEffectCaller::~ShaderEffectCaller()

--- a/src/core/ShaderEffects/shadereffectcaller.h
+++ b/src/core/ShaderEffects/shadereffectcaller.h
@@ -26,6 +26,7 @@
 #ifndef SHADEREFFECTCALLER_H
 #define SHADEREFFECTCALLER_H
 #include "RasterEffects/rastereffectcaller.h"
+#include "ShaderEffects/shadereffect.h"
 #include "shadereffectprogram.h"
 #include "../gpurendertools.h"
 #include "shadereffectjs.h"
@@ -39,6 +40,11 @@ public:
 
     void processGpu(QGL33 * const gl,
                     GpuRenderTools& renderTools);
+
+    void calc(const ShaderEffect * pEff,
+              const qreal relFrame,
+              const qreal resolution,
+              const qreal influence);
 
     ShaderEffectJS& getJSEngine()
     { return *mEngine; }

--- a/src/core/ShaderEffects/shadereffectcaller.h
+++ b/src/core/ShaderEffects/shadereffectcaller.h
@@ -35,7 +35,11 @@ class CORE_EXPORT ShaderEffectCaller : public RasterEffectCaller {
     e_OBJECT
 public:
     ShaderEffectCaller(std::unique_ptr<ShaderEffectJS>&& engine,
-                       const ShaderEffectProgram& program);
+                       const ShaderEffectProgram& program,
+                       const ShaderEffect* parentEffect,
+                       const qreal& relFrame,
+                       const qreal& resolution,
+                       const qreal& influence);
     ~ShaderEffectCaller();
 
     void processGpu(QGL33 * const gl,

--- a/src/core/ShaderEffects/shadereffectjs.cpp
+++ b/src/core/ShaderEffects/shadereffectjs.cpp
@@ -82,7 +82,6 @@ ShaderEffectJS::ShaderEffectJS(const Blueprint& blueprint)
 
 void ShaderEffectJS::setValues(const QJSValueList& args)
 {
-    //m_eSet.call(args);
     ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSet.call(args); });
 }
 
@@ -103,7 +102,6 @@ QJSValueList &ShaderEffectJS::getSetters()
 
 void ShaderEffectJS::evaluate()
 {
-    //m_eEvaluate.call();
     ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eEvaluate.call(); });
 }
 
@@ -114,7 +112,6 @@ int ShaderEffectJS::glValueCount() const
 
 QJSValue ShaderEffectJS::getGlValue(const int index)
 {
-    //return mGlValueGetters[index].call();
     return ThreadSafeQJSEngine::call(&mEngine, [&]{ return mGlValueGetters[index].call(); });
 }
 
@@ -123,10 +120,59 @@ QJSValue& ShaderEffectJS::getGlValueGetter(const int index)
     return mGlValueGetters[index];
 }
 
+double ShaderEffectJS::getGlValueDouble(const int index)
+{
+    const QJSValue val = getGlValue(index);
+    if (val.isNumber()) {
+        return val.toNumber();
+    } else { RuntimeThrow("Invalid value. Expected double."); }
+}
+
+ShaderEffectJS::DV2 ShaderEffectJS::getGlValueDouble2(const int index)
+{
+    DV2 vec;
+    const QJSValue val = getGlValue(index);
+    if (val.isArray()) {
+        const int len = val.property("length").toInt();
+        if (len != 2) { RuntimeThrow("Invalid value. Expected vec2."); }
+        vec.v0 = val.property(0).toNumber();
+        vec.v1 = val.property(1).toNumber();
+        return vec;
+    } else { RuntimeThrow("Invalid value. Expected vec2."); }
+}
+
+ShaderEffectJS::DV3 ShaderEffectJS::getGlValueDouble3(const int index)
+{
+    DV3 vec;
+    const QJSValue val = getGlValue(index);
+    if (val.isArray()) {
+        const int len = val.property("length").toInt();
+        if (len != 3) { RuntimeThrow("Invalid value. Expected vec3."); }
+        vec.v0 = val.property(0).toNumber();
+        vec.v1 = val.property(1).toNumber();
+        vec.v2 = val.property(2).toNumber();
+        return vec;
+    } else { RuntimeThrow("Invalid value. Expected vec3."); }
+}
+
+ShaderEffectJS::DV4 ShaderEffectJS::getGlValueDouble4(const int index)
+{
+    DV4 vec;
+    const QJSValue val = getGlValue(index);
+    if (val.isArray()) {
+        const int len = val.property("length").toInt();
+        if (len != 4) { RuntimeThrow("Invalid value. Expected vec4."); }
+        vec.v0 = val.property(0).toNumber();
+        vec.v1 = val.property(1).toNumber();
+        vec.v2 = val.property(2).toNumber();
+        vec.v3 = val.property(3).toNumber();
+        return vec;
+    } else { RuntimeThrow("Invalid value. Expected vec4."); }
+}
+
 QJSValue ShaderEffectJS::getMarginValue()
 {
     if (!fMargin) { return 0.; }
-    //return mMarginGetter.call();
     return ThreadSafeQJSEngine::call(&mEngine, [&]{ return mMarginGetter.call(); });
 }
 
@@ -161,7 +207,6 @@ void ShaderEffectJS::setSceneRect(const SkIRect& rect)
     args << rect.y();
     args << rect.width();
     args << rect.height();
-    //m_eSetSceneRect.call(args);
     ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSetSceneRect.call(args); });
 }
 

--- a/src/core/ShaderEffects/shadereffectjs.cpp
+++ b/src/core/ShaderEffects/shadereffectjs.cpp
@@ -27,103 +27,130 @@
 
 #include <QPointF>
 #include <QColor>
+#include <QRegularExpression>
 
 #include "exceptions.h"
+#include "threadsafeqjsengine.h"
 
 #define MARGIN_VAR_NAME "_eMargin"
 #define MARGIN_GETTER_NAME "_eGet" MARGIN_VAR_NAME
 
-QString glValueGetterName(const QString& glValueName) {
+QString glValueGetterName(const QString& glValueName)
+{
     return "_eGet_" + glValueName;
 }
 
 
-void throwIfIsError(const QJSValue& value, const QString& name) {
-    if(value.isError()) {
+void throwIfIsError(const QJSValue& value, const QString& name)
+{
+    if (value.isError()) {
         RuntimeThrow("Uncaught exception in " + name + " at line "
                      + value.property("lineNumber").toString() +
                      ":\n" + value.toString());
     }
 }
 
-ShaderEffectJS::ShaderEffectJS(const Blueprint& blueprint) :
-    fMargin(blueprint.fMargin) {
+ShaderEffectJS::ShaderEffectJS(const Blueprint& blueprint)
+    : fMargin(blueprint.fMargin)
+{
     const auto eClass = mEngine.evaluate(blueprint.fClassDef);
     throwIfIsError(eClass, "eClass");
+
     const auto eObj = mEngine.evaluate("var _eObj; _eObj = new _eClass()");
     throwIfIsError(eObj, "eObj");
+
     m_eSetSceneRect = mEngine.evaluate("_eObj._eSetSceneRect");
     throwIfIsError(m_eSetSceneRect, "m_eSetSceneRect");
+
     m_eSet = mEngine.evaluate("_eObj._eSet");
     throwIfIsError(m_eSet, "m_eSet");
+
     m_eEvaluate = mEngine.evaluate("_eObj._eEvaluate");
     throwIfIsError(m_eEvaluate, "m_eEvaluate");
-    for(const auto& glVal : blueprint.fGlValues) {
+
+    for (const auto& glVal : blueprint.fGlValues) {
         const auto getterName = glValueGetterName(glVal);
         auto getter = mEngine.evaluate("_eObj." + getterName);
         mGlValueGetters.append(getter);
     }
-    if(fMargin) {
+
+    if (fMargin) {
         mMarginGetter = mEngine.evaluate("_eObj." MARGIN_GETTER_NAME);
     }
 }
 
-void ShaderEffectJS::setValues(const QJSValueList& args) {
-    m_eSet.call(args);
+void ShaderEffectJS::setValues(const QJSValueList& args)
+{
+    //m_eSet.call(args);
+    ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSet.call(args); });
 }
 
-void ShaderEffectJS::evaluate() {
-    m_eEvaluate.call();
+void ShaderEffectJS::evaluate()
+{
+    //m_eEvaluate.call();
+    ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eEvaluate.call(); });
 }
 
-int ShaderEffectJS::glValueCount() const {
+int ShaderEffectJS::glValueCount() const
+{
     return mGlValueGetters.count();
 }
 
-QJSValue ShaderEffectJS::getGlValue(const int index) {
-    return mGlValueGetters[index].call();
+QJSValue ShaderEffectJS::getGlValue(const int index)
+{
+    //return mGlValueGetters[index].call();
+    return ThreadSafeQJSEngine::call(&mEngine, [&]{ return mGlValueGetters[index].call(); });
 }
 
-QJSValue& ShaderEffectJS::getGlValueGetter(const int index) {
+QJSValue& ShaderEffectJS::getGlValueGetter(const int index)
+{
     return mGlValueGetters[index];
 }
 
-QJSValue ShaderEffectJS::getMarginValue() {
-    if(!fMargin) return 0.;
-    return mMarginGetter.call();
+QJSValue ShaderEffectJS::getMarginValue()
+{
+    if (!fMargin) { return 0.; }
+    //return mMarginGetter.call();
+    return ThreadSafeQJSEngine::call(&mEngine, [&]{ return mMarginGetter.call(); });
 }
 
-void ShaderEffectJS::setSceneRect(const SkIRect& rect) {
+void ShaderEffectJS::setSceneRect(const SkIRect& rect)
+{
     QJSValueList args;
     args << rect.x();
     args << rect.y();
     args << rect.width();
     args << rect.height();
-    m_eSetSceneRect.call(args);
+    //m_eSetSceneRect.call(args);
+    ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSetSceneRect.call(args); });
 }
 
-QJSValue ShaderEffectJS::toValue(const QPointF& val) {
+QJSValue ShaderEffectJS::toValue(const QPointF& val)
+{
     QJSValue arr = mEngine.newArray(2);
     arr.setProperty(0, val.x());
     arr.setProperty(1, val.y());
+
     return arr;
 }
 
-QJSValue ShaderEffectJS::toValue(const QColor& val) {
+QJSValue ShaderEffectJS::toValue(const QColor& val)
+{
     QJSValue arr = mEngine.newArray(4);
     arr.setProperty(0, val.redF());
     arr.setProperty(1, val.greenF());
     arr.setProperty(2, val.blueF());
     arr.setProperty(3, val.alphaF());
+
     return arr;
 }
 
-#include <QRegularExpression>
-QStringList extractExternFromScript(QString& calc) {
+QStringList extractExternFromScript(QString& calc)
+{
     QStringList result;
     QRegularExpression rx("\\bextern\\s+([a-zA-Z_][a-zA-Z_0-9]*)");
     auto matchIterator = rx.globalMatch(calc);
-    while(matchIterator.hasNext()) {
+    while (matchIterator.hasNext()) {
         const auto match = matchIterator.next();
         result << match.captured(1);
     }
@@ -148,22 +175,21 @@ QStringList extractExternFromScript(QString& calc) {
 //     -_eMargin Getter Functions
 // }
 std::shared_ptr<ShaderEffectJS::Blueprint>
-ShaderEffectJS::Blueprint::sCreate(
-        const QString& defs, QString calc,
-        const QStringList& properties,
-        const QList<GlValueBlueprint>& glValueBPs,
-        const QString& marginScript) {
+ShaderEffectJS::Blueprint::sCreate(const QString& defs, QString calc,
+                                   const QStringList& properties,
+                                   const QList<GlValueBlueprint>& glValueBPs,
+                                   const QString& marginScript)
+{
     const QStringList externVars = extractExternFromScript(calc);
     QString externDefs;
-    for(const auto& ext : externVars) {
+    for (const auto& ext : externVars) {
         externDefs += "var " + ext + ";\n";
     }
-    const QString _eSetArgs =
-            properties.isEmpty() ? "" : ("_" + properties.join(",_"));
+    const QString _eSetArgs = properties.isEmpty() ? "" : ("_" + properties.join(",_"));
 
     QString propDefs;
     QString _eSet = "\nthis._eSet = function(" + _eSetArgs + ") {\n";
-        for(const auto& prop : properties) {
+        for (const auto& prop : properties) {
             propDefs += "var " + prop + ";\n";
             _eSet += "" + prop + "=_" + prop + ";\n";
         }
@@ -174,7 +200,7 @@ ShaderEffectJS::Blueprint::sCreate(
     QString glValueDefs;
     const QString _eEval_Args = properties.join(",");
     QString _eEvaluate = "\nthis._eEvaluate = function() {\n" + calc;
-        for(const auto& glVal : glValueBPs) {
+        for (const auto& glVal : glValueBPs) {
             glValues << glVal.fName;
             glValueDefs += "var " + glVal.fName + ";\n";
             _eEvaluate += glVal.fName + "=" + glVal.fScript + ";\n";
@@ -184,7 +210,7 @@ ShaderEffectJS::Blueprint::sCreate(
                        "};\n";
         }
         const bool hasMargin = !marginScript.isEmpty();
-        if(hasMargin) {
+        if (hasMargin) {
             glValueDefs += "var " MARGIN_VAR_NAME ";\n";
             _eEvaluate += MARGIN_VAR_NAME "=" + marginScript + ";\n";
             getters += "\nthis." MARGIN_GETTER_NAME " = function() {\n"
@@ -201,5 +227,6 @@ ShaderEffectJS::Blueprint::sCreate(
     const QString classContent = defs + externDefs + propDefs + "\nvar _eRect;\n" +
                                  _eSet + glValueDefs + _eEvaluate + _eSetSceneRect + getters;
     const QString classDef = "function _eClass() {\n" + classContent + "\n}";
+
     return std::shared_ptr<Blueprint>(new Blueprint{classDef, glValues, hasMargin});
 }

--- a/src/core/ShaderEffects/shadereffectjs.cpp
+++ b/src/core/ShaderEffects/shadereffectjs.cpp
@@ -86,6 +86,21 @@ void ShaderEffectJS::setValues(const QJSValueList& args)
     ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSet.call(args); });
 }
 
+void ShaderEffectJS::updateValues()
+{
+    ThreadSafeQJSEngine::call(&mEngine, [&]{ m_eSet.call(mSetters); });
+}
+
+void ShaderEffectJS::clearSetters()
+{
+    mSetters.clear();
+}
+
+QJSValueList &ShaderEffectJS::getSetters()
+{
+    return mSetters;
+}
+
 void ShaderEffectJS::evaluate()
 {
     //m_eEvaluate.call();

--- a/src/core/ShaderEffects/shadereffectjs.cpp
+++ b/src/core/ShaderEffects/shadereffectjs.cpp
@@ -210,7 +210,7 @@ const QMargins ShaderEffectJS::getMargins()
     return QMargins();
 }
 
-#pragma warning("This still may segfault (on Linux with a bunch of effects)")
+#pragma message("This still may segfault (on Linux with a bunch of effects)")
 void ShaderEffectJS::setSceneRect(const SkIRect& rect)
 {
     QJSValueList args;

--- a/src/core/ShaderEffects/shadereffectjs.cpp
+++ b/src/core/ShaderEffects/shadereffectjs.cpp
@@ -95,9 +95,19 @@ void ShaderEffectJS::clearSetters()
     mSetters.clear();
 }
 
-QJSValueList &ShaderEffectJS::getSetters()
+void ShaderEffectJS::addSetter(const QPointF &val)
 {
-    return mSetters;
+    mSetters << toValue(val);
+}
+
+void ShaderEffectJS::addSetter(const QColor &val)
+{
+    mSetters << toValue(val);
+}
+
+void ShaderEffectJS::addSetter(const qreal &val)
+{
+    mSetters << val;
 }
 
 void ShaderEffectJS::evaluate()
@@ -200,6 +210,7 @@ const QMargins ShaderEffectJS::getMargins()
     return QMargins();
 }
 
+#pragma warning("This still may segfault (on Linux with a bunch of effects)")
 void ShaderEffectJS::setSceneRect(const SkIRect& rect)
 {
     QJSValueList args;

--- a/src/core/ShaderEffects/shadereffectjs.h
+++ b/src/core/ShaderEffects/shadereffectjs.h
@@ -36,6 +36,24 @@
 
 class CORE_EXPORT ShaderEffectJS {
 public:
+    struct DV2
+    {
+        double v0;
+        double v1;
+    };
+    struct DV3
+    {
+        double v0;
+        double v1;
+        double v2;
+    };
+    struct DV4
+    {
+        double v0;
+        double v1;
+        double v2;
+        double v3;
+    };
     struct Blueprint;
     ShaderEffectJS(const Blueprint& blueprint);
 
@@ -67,6 +85,11 @@ public:
     QJSValue getGlValue(const int index);
 
     QJSValue& getGlValueGetter(const int index);
+
+    double getGlValueDouble(const int index);
+    DV2 getGlValueDouble2(const int index);
+    DV3 getGlValueDouble3(const int index);
+    DV4 getGlValueDouble4(const int index);
 
     const bool fMargin;
     QJSValue getMarginValue();

--- a/src/core/ShaderEffects/shadereffectjs.h
+++ b/src/core/ShaderEffects/shadereffectjs.h
@@ -57,6 +57,9 @@ public:
     };
 
     void setValues(const QJSValueList& args);
+    void updateValues();
+    void clearSetters();
+    QJSValueList& getSetters();
 
     void evaluate();
 
@@ -80,6 +83,7 @@ private:
     QJSValue m_eEvaluate;
     QJSValueList mGlValueGetters;
     QJSValue mMarginGetter;
+    QJSValueList mSetters;
 };
 
 #endif // SHADEREFFECTJS_H

--- a/src/core/ShaderEffects/shadereffectjs.h
+++ b/src/core/ShaderEffects/shadereffectjs.h
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <QJSEngine>
+#include <QMargins>
 
 class CORE_EXPORT ShaderEffectJS {
 public:
@@ -66,6 +67,7 @@ public:
 
     const bool fMargin;
     QJSValue getMarginValue();
+    const QMargins getMargins();
 
     void setSceneRect(const SkIRect& rect);
 

--- a/src/core/ShaderEffects/shadereffectjs.h
+++ b/src/core/ShaderEffects/shadereffectjs.h
@@ -77,7 +77,9 @@ public:
     void setValues(const QJSValueList& args);
     void updateValues();
     void clearSetters();
-    QJSValueList& getSetters();
+    void addSetter(const QPointF& val);
+    void addSetter(const QColor& val);
+    void addSetter(const qreal& val);
 
     void evaluate();
 

--- a/src/core/ShaderEffects/shadervaluehandler.cpp
+++ b/src/core/ShaderEffects/shadervaluehandler.cpp
@@ -30,143 +30,70 @@ ShaderValueHandler::ShaderValueHandler(const QString &name,
                                        const QString& script):
     fName(name), fScript(script), mType(type) {}
 
-UniformSpecifier ShaderValueHandler::create(const GLint loc, QJSValue* getter) const {
+UniformSpecifier ShaderValueHandler::create(const GLint loc,
+                                            ShaderEffectJS &engine,
+                                            int index) const
+{
     Q_ASSERT(loc >= 0);
     switch(mType) {
     case GLValueType::Float:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isNumber()) {
-                gl->glUniform1f(loc, static_cast<GLfloat>(jsVal.toNumber()));
-            } else RuntimeThrow("Invalid value. Expected float.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble(index);
+            gl->glUniform1f(loc, static_cast<GLfloat>(val));
         };
     case GLValueType::Vec2:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 2) RuntimeThrow("Invalid value. Expected vec2.");
-                const qreal val0 = jsVal.property(0).toNumber();
-                const qreal val1 = jsVal.property(1).toNumber();
-
-                gl->glUniform2f(loc, static_cast<GLfloat>(val0),
-                                static_cast<GLfloat>(val1));
-            } else RuntimeThrow("Invalid value. Expected vec2.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble2(index);
+            gl->glUniform2f(loc,
+                            static_cast<GLfloat>(val.v0),
+                            static_cast<GLfloat>(val.v1));
         };
     case GLValueType::Vec3:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 3) RuntimeThrow("Invalid value. Expected vec3.");
-                const qreal val0 = jsVal.property(0).toNumber();
-                const qreal val1 = jsVal.property(1).toNumber();
-                const qreal val2 = jsVal.property(2).toNumber();
-
-                gl->glUniform3f(loc, static_cast<GLfloat>(val0),
-                                static_cast<GLfloat>(val1),
-                                static_cast<GLfloat>(val2));
-            } else RuntimeThrow("Invalid value. Expected vec3.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble3(index);
+            gl->glUniform3f(loc,
+                            static_cast<GLfloat>(val.v0),
+                            static_cast<GLfloat>(val.v1),
+                            static_cast<GLfloat>(val.v2));
         };
     case GLValueType::Vec4:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 4) RuntimeThrow("Invalid value. Expected vec4.");
-                const qreal val0 = jsVal.property(0).toNumber();
-                const qreal val1 = jsVal.property(1).toNumber();
-                const qreal val2 = jsVal.property(2).toNumber();
-                const qreal val3 = jsVal.property(3).toNumber();
-
-                gl->glUniform4f(loc, static_cast<GLfloat>(val0),
-                                static_cast<GLfloat>(val1),
-                                static_cast<GLfloat>(val2),
-                                static_cast<GLfloat>(val3));
-            } else RuntimeThrow("Invalid value. Expected vec4.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble4(index);
+            gl->glUniform4f(loc,
+                            static_cast<GLfloat>(val.v0),
+                            static_cast<GLfloat>(val.v1),
+                            static_cast<GLfloat>(val.v2),
+                            static_cast<GLfloat>(val.v3));
         };
     case GLValueType::Int:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isNumber()) {
-                const int val = qRound(jsVal.toNumber());
-                gl->glUniform1i(loc, static_cast<GLint>(val));
-            } else RuntimeThrow("Invalid value. Expected int.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble(index);
+            gl->glUniform1i(loc, static_cast<GLint>(qRound(val)));
         };
     case GLValueType::iVec2:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 2) RuntimeThrow("Invalid value. Expected ivec2.");
-                const int val0 = qRound(jsVal.property(0).toNumber());
-                const int val1 = qRound(jsVal.property(1).toNumber());
-
-                gl->glUniform2i(loc, static_cast<GLint>(val0),
-                                static_cast<GLint>(val1));
-            } else RuntimeThrow("Invalid value. Expected ivec2.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble2(index);
+            gl->glUniform2i(loc,
+                            static_cast<GLint>(qRound(val.v0)),
+                            static_cast<GLint>(qRound(val.v1)));
         };
     case GLValueType::iVec3:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 3) RuntimeThrow("Invalid value. Expected ivec3.");
-                const int val0 = qRound(jsVal.property(0).toNumber());
-                const int val1 = qRound(jsVal.property(1).toNumber());
-                const int val2 = qRound(jsVal.property(2).toNumber());
-
-                gl->glUniform3i(loc, static_cast<GLint>(val0),
-                                static_cast<GLint>(val1),
-                                static_cast<GLint>(val2));
-            } else RuntimeThrow("Invalid value. Expected ivec3.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble3(index);
+            gl->glUniform3i(loc,
+                            static_cast<GLint>(qRound(val.v0)),
+                            static_cast<GLint>(qRound(val.v1)),
+                            static_cast<GLint>(qRound(val.v2)));
         };
     case GLValueType::iVec4:
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 4) RuntimeThrow("Invalid value. Expected ivec4.");
-                const int val0 = qRound(jsVal.property(0).toNumber());
-                const int val1 = qRound(jsVal.property(1).toNumber());
-                const int val2 = qRound(jsVal.property(2).toNumber());
-                const int val3 = qRound(jsVal.property(3).toNumber());
-
-                gl->glUniform4i(loc, static_cast<GLint>(val0),
-                                static_cast<GLint>(val1),
-                                static_cast<GLint>(val2),
-                                static_cast<GLint>(val3));
-            } else RuntimeThrow("Invalid value. Expected ivec4.");
+        return [loc, &engine, index](QGL33 * const gl) {
+            const auto val = engine.getGlValueDouble4(index);
+            gl->glUniform4i(loc,
+                            static_cast<GLint>(qRound(val.v0)),
+                            static_cast<GLint>(qRound(val.v1)),
+                            static_cast<GLint>(qRound(val.v2)),
+                            static_cast<GLint>(qRound(val.v3)));
         };
     default: RuntimeThrow("Unsupported type for " + fName);
     }
-
-    if(mType == GLValueType::Float) {
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isNumber()) {
-                gl->glUniform1f(loc, static_cast<GLfloat>(jsVal.toNumber()));
-            } else RuntimeThrow("Invalid value. Expected float.");
-        };
-    } else if(mType == GLValueType::Int) {
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isNumber()) {
-                gl->glUniform1i(loc, static_cast<GLint>(jsVal.toInt()));
-            } else RuntimeThrow("Invalid value. Expected int.");
-        };
-    } else if(mType == GLValueType::Vec2) {
-        return [loc, getter](QGL33 * const gl) {
-            const QJSValue jsVal = getter->call();
-            if(jsVal.isArray()) {
-                const int len = jsVal.property("length").toInt();
-                if(len != 2) RuntimeThrow("Invalid value. Expected vec2.");
-                const qreal val0 = jsVal.property(0).toNumber();
-                const qreal val1 = jsVal.property(1).toNumber();
-
-                gl->glUniform2f(loc, static_cast<GLfloat>(val0),
-                                static_cast<GLfloat>(val1));
-            } else RuntimeThrow("Invalid value. Expected vec2.");
-        };
-    } else RuntimeThrow("Unsupported type for " + fName);
 }

--- a/src/core/ShaderEffects/shadervaluehandler.h
+++ b/src/core/ShaderEffects/shadervaluehandler.h
@@ -27,6 +27,7 @@
 #define SHADERVALUEHANDLER_H
 #include <QJSEngine>
 
+#include "ShaderEffects/shadereffectjs.h"
 #include "glhelpers.h"
 #include "smartPointers/ememory.h"
 
@@ -38,15 +39,19 @@ enum class GLValueType {
     none
 };
 
-class CORE_EXPORT ShaderValueHandler : public StdSelfRef {
+class CORE_EXPORT ShaderValueHandler : public StdSelfRef
+{
 public:
     ShaderValueHandler(const QString& name, const GLValueType type,
                        const QString& script);
 
-    UniformSpecifier create(const GLint loc, QJSValue* getter) const;
+    UniformSpecifier create(const GLint loc,
+                            ShaderEffectJS &engine,
+                            int index) const;
 
     const QString fName;
     const QString fScript;
+
 private:
     const GLValueType mType;
 };

--- a/src/core/ShaderEffects/uniformspecifiercreator.cpp
+++ b/src/core/ShaderEffects/uniformspecifiercreator.cpp
@@ -27,97 +27,99 @@
 
 #include "shadereffectjs.h"
 
-void qrealAnimatorCreate(
-        const bool glValue,
-        const GLint loc,
-        Property * const property,
-        const qreal relFrame,
-        const qreal resolution,
-        const qreal influence,
-        QJSValueList& setterArgs,
-        UniformSpecifiers& uniSpec) {
+void qrealAnimatorCreate(ShaderEffectJS &engine,
+                         const bool glValue,
+                         const GLint loc,
+                         Property * const property,
+                         const qreal relFrame,
+                         const qreal resolution,
+                         const qreal influence,
+                         UniformSpecifiers& uniSpec)
+{
     const auto anim = static_cast<QrealAnimator*>(property);
     const qreal val = anim->getEffectiveValue(relFrame)*resolution*influence;
     const QString propName = anim->prp_getName();
     const QString valScript = propName + " = " + QString::number(val);
-    setterArgs << val;
+    engine.addSetter(val);
 
-    if(!glValue) return;
+    if (!glValue) { return; }
     Q_ASSERT(loc >= 0);
     uniSpec << [loc, val, valScript](QGL33 * const gl) {
         gl->glUniform1f(loc, static_cast<GLfloat>(val));
     };
 }
 
-void intAnimatorCreate(
-        const bool glValue,
-        const GLint loc,
-        Property * const property,
-        const qreal relFrame,
-        const qreal resolution,
-        const qreal influence,
-        QJSValueList& setterArgs,
-        UniformSpecifiers& uniSpec) {
+void intAnimatorCreate(ShaderEffectJS &engine,
+                       const bool glValue,
+                       const GLint loc,
+                       Property * const property,
+                       const qreal relFrame,
+                       const qreal resolution,
+                       const qreal influence,
+                       UniformSpecifiers& uniSpec)
+{
     const auto anim = static_cast<IntAnimator*>(property);
     const int val = qRound(anim->getEffectiveIntValue(relFrame)*resolution*influence);
     const QString valScript = anim->prp_getName() + " = " + QString::number(val);
-    setterArgs << val;
+    engine.addSetter(val);
 
-    if(!glValue) return;
+    if (!glValue) { return; }
     Q_ASSERT(loc >= 0);
     uniSpec << [loc, val, valScript](QGL33 * const gl) {
         gl->glUniform1i(loc, val);
     };
 }
 
-QString vec2ValScript(const QString& name, const QPointF& value) {
+QString vec2ValScript(const QString& name,
+                      const QPointF& value)
+{
     return name + " = [" + QString::number(value.x()) + "," +
                            QString::number(value.y()) + "]";
 }
 
-void qPointFAnimatorCreate(
-        ShaderEffectJS &engine,
-        const bool glValue,
-        const GLint loc,
-        Property * const property,
-        const qreal relFrame,
-        const qreal resolution,
-        const qreal influence,
-        QJSValueList& setterArgs,
-        UniformSpecifiers& uniSpec) {
+void qPointFAnimatorCreate(ShaderEffectJS &engine,
+                           const bool glValue,
+                           const GLint loc,
+                           Property * const property,
+                           const qreal relFrame,
+                           const qreal resolution,
+                           const qreal influence,
+                           UniformSpecifiers& uniSpec)
+{
     const auto anim = static_cast<QPointFAnimator*>(property);
     const QPointF val = anim->getEffectiveValue(relFrame)*resolution*influence;
     const QString valScript = vec2ValScript(anim->prp_getName(), val);
-    setterArgs << engine.toValue(val);
+    engine.addSetter(val);
 
-    if(!glValue) return;
+    if (!glValue) { return; }
     Q_ASSERT(loc >= 0);
     uniSpec << [loc, val, valScript](QGL33 * const gl) {
         gl->glUniform2f(loc, val.x(), val.y());
     };
 }
 
-QString colorValScript(const QString& name, const QColor& value) {
+QString colorValScript(const QString& name,
+                       const QColor& value)
+{
     return name + " = [" + QString::number(value.redF()) + "," +
                            QString::number(value.greenF()) + "," +
                            QString::number(value.blueF()) + "," +
                            QString::number(value.alphaF()) + "]";
 }
 
-void colorAnimatorCreate(
-        ShaderEffectJS &engine,
-        const bool glValue,
-        const GLint loc,
-        Property * const property,
-        const qreal relFrame,
-        QJSValueList& setterArgs,
-        UniformSpecifiers& uniSpec) {
+void colorAnimatorCreate(ShaderEffectJS &engine,
+                         const bool glValue,
+                         const GLint loc,
+                         Property * const property,
+                         const qreal relFrame,
+                         UniformSpecifiers& uniSpec)
+{
     const auto anim = static_cast<ColorAnimator*>(property);
     const QColor val = anim->getColor(relFrame);
     const QString valScript = colorValScript(anim->prp_getName(), val);
-    setterArgs << engine.toValue(val);
+    engine.addSetter(val);
 
-    if(!glValue) return;
+    if (!glValue) { return; }
     Q_ASSERT(loc >= 0);
     uniSpec << [loc, val, valScript](QGL33 * const gl) {
         gl->glUniform4f(loc, val.redF(), val.greenF(), val.blueF(),
@@ -131,27 +133,43 @@ void UniformSpecifierCreator::create(ShaderEffectJS &engine,
                                      const qreal relFrame,
                                      const qreal resolution,
                                      const qreal influence,
-                                     QJSValueList& setterArgs,
-                                     UniformSpecifiers& uniSpec) const {
+                                     UniformSpecifiers& uniSpec) const
+{
     switch(mType) {
     case ShaderPropertyType::floatProperty:
-        return qrealAnimatorCreate(fGLValue, loc, property, relFrame,
+        return qrealAnimatorCreate(engine,
+                                   fGLValue,
+                                   loc,
+                                   property,
+                                   relFrame,
                                    mResolutionScaled ? resolution : 1,
                                    mInfluenceScaled ? influence : 1,
-                                   setterArgs, uniSpec);
+                                   uniSpec);
     case ShaderPropertyType::intProperty:
-        return intAnimatorCreate(fGLValue, loc, property, relFrame,
+        return intAnimatorCreate(engine,
+                                 fGLValue,
+                                 loc,
+                                 property,
+                                 relFrame,
                                  mResolutionScaled ? resolution : 1,
                                  mInfluenceScaled ? influence : 1,
-                                 setterArgs, uniSpec);
+                                 uniSpec);
     case ShaderPropertyType::vec2Property:
-        return qPointFAnimatorCreate(engine, fGLValue, loc, property, relFrame,
+        return qPointFAnimatorCreate(engine,
+                                     fGLValue,
+                                     loc,
+                                     property,
+                                     relFrame,
                                      mResolutionScaled ? resolution : 1,
                                      mInfluenceScaled ? influence : 1,
-                                     setterArgs, uniSpec);
+                                     uniSpec);
     case ShaderPropertyType::colorProperty:
-        return colorAnimatorCreate(engine, fGLValue, loc, property, relFrame,
-                                   setterArgs, uniSpec);
+        return colorAnimatorCreate(engine,
+                                   fGLValue,
+                                   loc,
+                                   property,
+                                   relFrame,
+                                   uniSpec);
     default: RuntimeThrow("Unsupported type");
     }
 }

--- a/src/core/ShaderEffects/uniformspecifiercreator.h
+++ b/src/core/ShaderEffects/uniformspecifiercreator.h
@@ -46,7 +46,8 @@ enum class ShaderPropertyType {
 
 typedef std::function<void(QGL33 * const)> UniformSpecifier;
 typedef QList<UniformSpecifier> UniformSpecifiers;
-struct CORE_EXPORT UniformSpecifierCreator : public StdSelfRef {
+struct CORE_EXPORT UniformSpecifierCreator : public StdSelfRef
+{
     UniformSpecifierCreator(const ShaderPropertyType type,
                             const bool glValue,
                             const bool resolutionScaled,
@@ -61,7 +62,6 @@ struct CORE_EXPORT UniformSpecifierCreator : public StdSelfRef {
                 const qreal relFrame,
                 const qreal resolution,
                 const qreal influence,
-                QJSValueList& setterArgs,
                 UniformSpecifiers& uniSpec) const;
 
     const ShaderPropertyType mType;

--- a/src/core/threadsafeqjsengine.h
+++ b/src/core/threadsafeqjsengine.h
@@ -1,0 +1,67 @@
+/*
+
+https://github.com/nst1911/thread-safe-qjsengine
+
+MIT License
+
+Copyright (c) 2022 Nikita Stelmashenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#ifndef THREADSAFEQJSENGINE_H
+#define THREADSAFEQJSENGINE_H
+
+#include <QJSEngine>
+#include <QThread>
+
+namespace ThreadSafeQJSEngine {
+
+template <typename F>
+auto call(QJSEngine* engine, F&& f) -> typename std::enable_if<!std::is_void<decltype(f())>::value, decltype(f())>::type
+{
+    if (QThread::currentThread() != engine->thread())
+    {
+        decltype(f()) result;
+        QMetaObject::invokeMethod(engine, std::forward<F>(f), Qt::BlockingQueuedConnection, &result);
+        return result;
+    }
+    else
+    {
+        return std::forward<F>(f)();
+    }
+}
+
+template <typename F>
+auto call(QJSEngine* engine, F&& f) -> typename std::enable_if<std::is_void<decltype(f())>::value, void>::type
+{
+    if (QThread::currentThread() != engine->thread())
+    {
+        QMetaObject::invokeMethod(engine, std::forward<F>(f), Qt::BlockingQueuedConnection);
+    }
+    else
+    {
+        std::forward<F>(f)();
+    }
+}
+
+};
+
+#endif // THREADSAFEQJSENGINE_H


### PR DESCRIPTION
This is the first refactor of the shader effects code. The goal is to keep all `QJSEngine` / `QJSValue` calculations and calls inside the `ShaderEffectJS` class.

This should improve stability when many shader effects are used in a project. See #64 for more information.

Everything should "just work" as usual, I have been careful to not modify the actual calculations or order. Tested on various projects with misc shader effects and I have not noticed any regressions.

Will provide binaries when I get the time.

***Note** that this is not a perfect fix. Qt might still crash if you have enough effects (mostly on Linux), but this PR bumps the stability to usable. The main goal is to remove usage of `QJSEngine` in shader effects with something better, this will be done in a v2 refactor sometime down the road.*