### PR TITLE
Fix linejoin and linecap support in SVG importer

### DIFF
--- a/src/core/svgimporter.cpp
+++ b/src/core/svgimporter.cpp
@@ -109,7 +109,7 @@ public:
 protected:
     qreal mOpacity = 1;
     QColor mColor;
-    PaintType mPaintType = NOPAINT;
+    PaintType mPaintType = FLATPAINT;
     Gradient *mGradient = nullptr;
     GradientType mGradientType = GradientType::LINEAR;
     QPointF mGradientP1;
@@ -119,7 +119,9 @@ protected:
 
 class StrokeSvgAttributes : public FillSvgAttributes {
 public:
-    StrokeSvgAttributes() {}
+    StrokeSvgAttributes() {
+        mPaintType = NOPAINT;
+    }
 
     qreal getLineWidth() const;
     SkPaint::Cap getCapStyle() const;
@@ -135,11 +137,11 @@ public:
 
     void apply(BoundingBox *box, const qreal scale) const;
 protected:
-    SkPaint::Cap mCapStyle = SkPaint::kRound_Cap;
-    SkPaint::Join mJoinStyle = SkPaint::kRound_Join;
+    SkPaint::Cap mCapStyle = SkPaint::kButt_Cap;
+    SkPaint::Join mJoinStyle = SkPaint::kMiter_Join;
     QPainter::CompositionMode mOutlineCompositionMode =
             QPainter::CompositionMode_Source;
-    qreal mLineWidth = 0;
+    qreal mLineWidth = 1;
 };
 
 class BoxSvgAttributes {
@@ -1256,6 +1258,8 @@ void StrokeSvgAttributes::setOutlineCompositionMode(const QPainter::CompositionM
 
 void StrokeSvgAttributes::apply(BoundingBox *box, const qreal scale) const {
     box->strokeWidthAction(QrealAction::sMakeSet(mLineWidth*scale));
+    box->setStrokeJoinStyle(mJoinStyle);
+    box->setStrokeCapStyle(mCapStyle);
     FillSvgAttributes::apply(box, PaintSetting::OUTLINE);
     //box->setStrokePaintType(mPaintType, mColor, mGradient);
 }


### PR DESCRIPTION
Fixes linecap and linejoin in SVG importer (issue #197).
![Screenshot 2024-06-30 210011](https://github.com/friction2d/friction/assets/8676441/3f8ea56b-c2ce-4a22-a5de-945b2d3a1b6f)

Further more, changed default values (no value is specified directly) of fill paint, stroke paint and stroke width according to svg specification. Fill paint = FLATPAINT, Stroke Paint = NOPAINT, StrokeWidth = 1.

Friction 0.96
![Screenshot 2024-06-30 211512](https://github.com/friction2d/friction/assets/8676441/51261d1c-88ee-4e47-90f9-ae9f6691bdaf)

SVG File


![Spiderman_clean](https://github.com/friction2d/friction/assets/8676441/1aae4e17-ed84-4dcb-867a-4ae9cd3bd9b2)
