### PR TITLE
Renderer: add FFmpeg options

### DIFF
--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -27,6 +27,7 @@
 #include "GUI/mainwindow.h"
 #include "GUI/global.h"
 #include "appsupport.h"
+#include "themesupport.h"
 #include "formatoptions.h"
 
 OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
@@ -69,8 +70,6 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
                      QList<AVCodecID>() << AV_CODEC_ID_MP3 << AV_CODEC_ID_AAC << AV_CODEC_ID_AC3 << AV_CODEC_ID_FLAC << AV_CODEC_ID_VORBIS << AV_CODEC_ID_WAVPACK,
         "*.aiff")
     };
-
-    setStyleSheet(MainWindow::sGetInstance()->styleSheet());
 
     mMainLayout = new QVBoxLayout(this);
     setLayout(mMainLayout);
@@ -318,6 +317,10 @@ void OutputSettingsDialog::updateAvailableCodecs() {
 
 void OutputSettingsDialog::setupFormatOptionsTree()
 {
+    mFormatOptionsTree->setPalette(
+        ThemeSupport::getDefaultPalette(
+            ThemeSupport::getThemeComboBaseColor()));
+
     const auto area = new QScrollArea(this);
     const auto container = new QWidget(this);
     const auto containerLayout = new QVBoxLayout(container);
@@ -348,26 +351,32 @@ void OutputSettingsDialog::setupFormatOptionsTree()
     mFormatOptionsTree->setRootIsDecorated(false);
     mFormatOptionsTree->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 
-    const auto mPushButtonAddFOpt = new QPushButton(QIcon::fromTheme("plus"),
-                                                    QString(),
-                                                    this);
-    const auto mPushButtonRemFOpt = new QPushButton(QIcon::fromTheme("minus"),
-                                                    QString(),
-                                                    this);
+    const auto addButton = new QPushButton(QIcon::fromTheme("plus"),
+                                           QString(),
+                                           this);
+    const auto remButton = new QPushButton(QIcon::fromTheme("minus"),
+                                           QString(),
+                                           this);
 
-    mPushButtonAddFOpt->setObjectName("FlatButton");
-    mPushButtonAddFOpt->setFocusPolicy(Qt::NoFocus);
-    mPushButtonRemFOpt->setObjectName("FlatButton");
-    mPushButtonRemFOpt->setFocusPolicy(Qt::NoFocus);
+    addButton->setObjectName("FlatButton");
+    addButton->setFocusPolicy(Qt::NoFocus);
+    remButton->setObjectName("FlatButton");
+    remButton->setFocusPolicy(Qt::NoFocus);
 
-    connect(mPushButtonAddFOpt, &QPushButton::pressed, this, [this]() {
+    eSizesUI::widget.add(addButton, [addButton,
+                                     remButton](const int size) {
+        addButton->setFixedHeight(size);
+        remButton->setFixedHeight(size);
+    });
+
+    connect(addButton, &QPushButton::pressed, this, [this]() {
         QTreeWidgetItem *item = new QTreeWidgetItem(mFormatOptionsTree);
         item->setFlags(item->flags() | Qt::ItemIsEditable);
         mFormatOptionsTree->addTopLevelItem(item);
         mFormatOptionsTree->setItemWidget(item, 0,
                                           createComboBoxFormatOptType());
     });
-    connect(mPushButtonRemFOpt, &QPushButton::pressed, this, [this]() {
+    connect(remButton, &QPushButton::pressed, this, [this]() {
         auto item = mFormatOptionsTree->selectedItems().count() > 0 ?
                         mFormatOptionsTree->selectedItems().at(0) : nullptr;
         if (!item) { return; }
@@ -375,9 +384,9 @@ void OutputSettingsDialog::setupFormatOptionsTree()
             mFormatOptionsTree->indexOfTopLevelItem(item));
     });
 
-    mFormatOptionsTree->addScrollBarWidget(mPushButtonRemFOpt,
+    mFormatOptionsTree->addScrollBarWidget(remButton,
                                            Qt::AlignBottom);
-    mFormatOptionsTree->addScrollBarWidget(mPushButtonAddFOpt,
+    mFormatOptionsTree->addScrollBarWidget(addButton,
                                            Qt::AlignBottom);
 
     containerInnerLayout->addWidget(mFormatOptionsTree);

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -30,6 +30,8 @@
 #include "themesupport.h"
 #include "formatoptions.h"
 
+using namespace Friction::Core;
+
 OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
                                            QWidget *parent) :
     QDialog(parent), mInitialSettings(settings) {

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -27,6 +27,7 @@
 #include "GUI/mainwindow.h"
 #include "GUI/global.h"
 #include "appsupport.h"
+#include "formatoptions.h"
 
 OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
                                            QWidget *parent) :
@@ -162,11 +163,16 @@ OutputSettingsDialog::OutputSettingsDialog(const OutputSettings &settings,
     eSizesUI::widget.addSpacing(mMainLayout);
     mVideoGroupBox->setLayout(mVideoSettingsLayout);
     mMainLayout->addWidget(mVideoGroupBox);
+
+    mFormatOptionsTree = new QTreeWidget(this);
+    setupFormatOptionsTree();
+
     mAudioGroupBox->setLayout(mAudioSettingsLayout);
     mMainLayout->addWidget(mAudioGroupBox);
     eSizesUI::widget.addSpacing(mMainLayout);
     mMainLayout->addLayout(mShowLayout);
     eSizesUI::widget.addSpacing(mMainLayout);
+    mMainLayout->addStretch();
     mMainLayout->addLayout(mButtonsLayout);
 
     connect(mVideoCodecsComboBox, &QComboBox::currentTextChanged, [this]() {
@@ -211,6 +217,7 @@ OutputSettings OutputSettingsDialog::getSettings() {
     settings.fVideoPixelFormat = currentPixelFormat;
     settings.fVideoBitrate = qRound(mBitrateSpinBox->value()*1000000);
     settings.fVideoProfile = mVideoProfileComboBox->currentData().toInt();
+    settings.fVideoOptions = getFormatOptions();
 
     settings.fAudioEnabled = mAudioGroupBox->isChecked();
     const AVCodec *currentAudioCodec = nullptr;
@@ -307,6 +314,139 @@ void OutputSettingsDialog::addAudioCodec(const AVCodecID &codecId,
 void OutputSettingsDialog::updateAvailableCodecs() {
     updateAvailableAudioCodecs();
     updateAvailableVideoCodecs();
+}
+
+void OutputSettingsDialog::setupFormatOptionsTree()
+{
+    const auto area = new QScrollArea(this);
+    const auto container = new QWidget(this);
+    const auto containerLayout = new QVBoxLayout(container);
+    const auto containerInner = new QWidget(this);
+    const auto containerInnerLayout = new QVBoxLayout(containerInner);
+
+    area->setWidget(containerInner);
+    area->setWidgetResizable(true);
+    area->setContentsMargins(0, 0, 0, 0);
+    area->setFrameShape(QFrame::NoFrame);
+
+    container->setContentsMargins(10, 0, 10, 0);
+    container->setMinimumHeight(150);
+    containerLayout->setMargin(0);
+    containerLayout->addWidget(area);
+
+    containerInner->setContentsMargins(0, 0, 0, 0);
+    containerInnerLayout->setMargin(0);
+
+    mFormatOptionsTree->setHeaderLabels(QStringList()
+                                        << tr("Type")
+                                        << tr("Key")
+                                        << tr("Value"));
+    mFormatOptionsTree->setTabKeyNavigation(true);
+    mFormatOptionsTree->setAlternatingRowColors(true);
+    mFormatOptionsTree->setSortingEnabled(false);
+    mFormatOptionsTree->setHeaderHidden(false);
+    mFormatOptionsTree->setRootIsDecorated(false);
+    mFormatOptionsTree->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+
+    const auto mPushButtonAddFOpt = new QPushButton(QIcon::fromTheme("plus"),
+                                                    QString(),
+                                                    this);
+    const auto mPushButtonRemFOpt = new QPushButton(QIcon::fromTheme("minus"),
+                                                    QString(),
+                                                    this);
+
+    mPushButtonAddFOpt->setObjectName("FlatButton");
+    mPushButtonAddFOpt->setFocusPolicy(Qt::NoFocus);
+    mPushButtonRemFOpt->setObjectName("FlatButton");
+    mPushButtonRemFOpt->setFocusPolicy(Qt::NoFocus);
+
+    connect(mPushButtonAddFOpt, &QPushButton::pressed, this, [this]() {
+        QTreeWidgetItem *item = new QTreeWidgetItem(mFormatOptionsTree);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        mFormatOptionsTree->addTopLevelItem(item);
+        mFormatOptionsTree->setItemWidget(item, 0,
+                                          createComboBoxFormatOptType());
+    });
+    connect(mPushButtonRemFOpt, &QPushButton::pressed, this, [this]() {
+        auto item = mFormatOptionsTree->selectedItems().count() > 0 ?
+                        mFormatOptionsTree->selectedItems().at(0) : nullptr;
+        if (!item) { return; }
+        delete mFormatOptionsTree->takeTopLevelItem(
+            mFormatOptionsTree->indexOfTopLevelItem(item));
+    });
+
+    mFormatOptionsTree->addScrollBarWidget(mPushButtonRemFOpt,
+                                           Qt::AlignBottom);
+    mFormatOptionsTree->addScrollBarWidget(mPushButtonAddFOpt,
+                                           Qt::AlignBottom);
+
+    containerInnerLayout->addWidget(mFormatOptionsTree);
+
+    const auto showHideWidget = new QWidget(this);
+    const auto showHideLayout = new QHBoxLayout(showHideWidget);
+    const auto showHideButton = new QPushButton(QIcon::fromTheme("go-down"),
+                                                tr("Advanced Options"),
+                                                this);
+
+    showHideButton->setCheckable(true);
+    showHideButton->setFocusPolicy(Qt::NoFocus);
+    connect(showHideButton, &QPushButton::released,
+            this, [container, showHideButton]() {
+        container->setVisible(showHideButton->isChecked());
+        showHideButton->setIcon(showHideButton->isChecked() ?
+                                    QIcon::fromTheme("go-up") :
+                                    QIcon::fromTheme("go-down"));
+    });
+
+    showHideWidget->setContentsMargins(0, 0, 10, 0);
+    showHideLayout->setMargin(0);
+    showHideLayout->addStretch();
+    showHideLayout->addWidget(showHideButton);
+
+    container->setVisible(false);
+    mMainLayout->addWidget(showHideWidget);
+    mMainLayout->addWidget(container);
+}
+
+void OutputSettingsDialog::populateFormatOptionsTree(const FormatOptions &options)
+{
+    mFormatOptionsTree->clear();
+    for (const auto &option : options.fValues) {
+        if (option.fKey.isEmpty()) { continue; }
+        QTreeWidgetItem *item = new QTreeWidgetItem(mFormatOptionsTree);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        item->setText(1, option.fKey);
+        item->setText(2, option.fValue);
+        auto combo = createComboBoxFormatOptType(option.fType);
+        mFormatOptionsTree->addTopLevelItem(item);
+        mFormatOptionsTree->setItemWidget(item, 0, combo);
+    }
+}
+
+QComboBox *OutputSettingsDialog::createComboBoxFormatOptType(int selected)
+{
+    auto box = new QComboBox(mFormatOptionsTree);
+    box->addItem(tr("Meta"), FormatType::fTypeMeta);
+    box->addItem(tr("Format"), FormatType::fTypeFormat);
+    box->addItem(tr("Codec"), FormatType::fTypeCodec);
+    box->setCurrentIndex(selected);
+    return box;
+}
+
+FormatOptions OutputSettingsDialog::getFormatOptions()
+{
+    FormatOptions options;
+    for (int i = 0; i < mFormatOptionsTree->topLevelItemCount(); i++) {
+        const auto item = mFormatOptionsTree->topLevelItem(i);
+        const auto combo = qobject_cast<QComboBox*>(mFormatOptionsTree->itemWidget(item, 0));
+        if (!combo) { continue; }
+        const auto key = item->text(1);
+        const auto val = item->text(2);
+        if (key.isEmpty()) { continue; }
+        options.fValues.push_back({key, val,
+                                   combo->currentData().toInt()});
+    }
+    return options;
 }
 
 void OutputSettingsDialog::updateAvailableVideoCodecs() {
@@ -749,6 +889,8 @@ void OutputSettingsDialog::restoreInitialSettings() {
     const bool noAudioCodecs = mAudioCodecsComboBox->count() == 0;
     mAudioGroupBox->setChecked(mInitialSettings.fAudioEnabled &&
                                !noAudioCodecs);
+
+    populateFormatOptionsTree(mInitialSettings.fVideoOptions);
 }
 
 void OutputSettingsDialog::restoreVideoProfileSettings()

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.h
@@ -133,9 +133,9 @@ protected:
 
     QTreeWidget *mFormatOptionsTree;
     void setupFormatOptionsTree();
-    void populateFormatOptionsTree(const FormatOptions &options);
-    QComboBox *createComboBoxFormatOptType(int selected = FormatType::fTypeMeta);
-    FormatOptions getFormatOptions();
+    void populateFormatOptionsTree(const Friction::Core::FormatOptions &options);
+    QComboBox *createComboBoxFormatOptType(int selected = Friction::Core::FormatType::fTypeMeta);
+    Friction::Core::FormatOptions getFormatOptions();
 
     void addVideoCodec(const AVCodec * const codec,
                        const AVOutputFormat *outputFormat,

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.h
@@ -25,6 +25,7 @@
 
 #ifndef OUTPUTSETTINGSDIALOG_H
 #define OUTPUTSETTINGSDIALOG_H
+
 #include <QDialog>
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -33,8 +34,12 @@
 #include <QDoubleSpinBox>
 #include <QGroupBox>
 #include <QCheckBox>
+#include <QTreeWidget>
+#include <QTreeView>
+
 #include "renderinstancesettings.h"
 #include "widgets/twocolumnlayout.h"
+
 #define COMPLIENCE FF_COMPLIANCE_NORMAL
 
 class OutputSettingsDialog : public QDialog {
@@ -125,6 +130,13 @@ protected:
     QPushButton *mOkButton = nullptr;
     QPushButton *mCancelButton = nullptr;
     QPushButton *mResetButton = nullptr;
+
+    QTreeWidget *mFormatOptionsTree;
+    void setupFormatOptionsTree();
+    void populateFormatOptionsTree(const FormatOptions &options);
+    QComboBox *createComboBoxFormatOptType(int selected = FormatType::fTypeMeta);
+    FormatOptions getFormatOptions();
+
     void addVideoCodec(const AVCodec * const codec,
                        const AVOutputFormat *outputFormat,
                        const QString &currentCodecName);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -690,6 +690,7 @@ set(
     rendersettings.h
     renderinstancesettings.h
     videoencoder.h
+    formatoptions.h
 )
 
 if(NOT WIN32)

--- a/src/core/ReadWrite/ereadstream.cpp
+++ b/src/core/ReadWrite/ereadstream.cpp
@@ -6,6 +6,8 @@
 #include "evformat.h"
 #include "Boxes/boundingbox.h"
 
+using namespace Friction::Core;
+
 eReadFutureTable::eReadFutureTable(QIODevice * const main) : mMain(main) {}
 
 void eReadFutureTable::read() {

--- a/src/core/ReadWrite/ereadstream.cpp
+++ b/src/core/ReadWrite/ereadstream.cpp
@@ -160,4 +160,9 @@ eReadStream &eReadStream::operator>>(SimpleBrushWrapper *&brush) {
     return *this;
 }
 
+eReadStream &eReadStream::operator>>(FormatOptions &val) {
+    read(&val, sizeof(FormatOptions));
+    return *this;
+}
+
 int eReadStream::evFileVersion() const { return mEvFileVersion; }

--- a/src/core/ReadWrite/ereadstream.h
+++ b/src/core/ReadWrite/ereadstream.h
@@ -78,7 +78,7 @@ public:
     eReadStream& operator>>(QString &val);
     eReadStream& operator>>(QByteArray &val);
     eReadStream& operator>>(SimpleBrushWrapper*& brush);
-    eReadStream& operator>>(FormatOptions &val);
+    eReadStream& operator>>(Friction::Core::FormatOptions &val);
 
     QString readFilePath();
 

--- a/src/core/ReadWrite/ereadstream.h
+++ b/src/core/ReadWrite/ereadstream.h
@@ -4,6 +4,8 @@
 #include "../core_global.h"
 #include "efuturepos.h"
 #include "../XML/runtimewriteid.h"
+#include "formatoptions.h"
+
 #include <functional>
 
 #include <QIODevice>
@@ -76,6 +78,7 @@ public:
     eReadStream& operator>>(QString &val);
     eReadStream& operator>>(QByteArray &val);
     eReadStream& operator>>(SimpleBrushWrapper*& brush);
+    eReadStream& operator>>(FormatOptions &val);
 
     QString readFilePath();
 

--- a/src/core/ReadWrite/evformat.h
+++ b/src/core/ReadWrite/evformat.h
@@ -42,6 +42,7 @@ namespace EvFormat {
         effectCustomName = 27,
         markers = 28,
         svgBeginEnd = 29,
+        formatOptions = 30,
 
         nextVersion
     };

--- a/src/core/ReadWrite/ewritestream.cpp
+++ b/src/core/ReadWrite/ewritestream.cpp
@@ -140,3 +140,8 @@ eWriteStream &eWriteStream::operator<<(SimpleBrushWrapper * const brush) {
     *this << (brush ? brush->getBrushName() : "");
     return *this;
 }
+
+eWriteStream &eWriteStream::operator<<(const FormatOptions &val) {
+    write(&val, sizeof(FormatOptions));
+    return *this;
+}

--- a/src/core/ReadWrite/ewritestream.cpp
+++ b/src/core/ReadWrite/ewritestream.cpp
@@ -6,6 +6,8 @@
 #include "filefooter.h"
 #include "framerange.h"
 
+using namespace Friction::Core;
+
 void eWriteFutureTable::write(eWriteStream &dst) {
     for(const auto& future : mFutures) {
         dst.write(&future, sizeof(eFuturePos));

--- a/src/core/ReadWrite/ewritestream.h
+++ b/src/core/ReadWrite/ewritestream.h
@@ -81,7 +81,7 @@ public:
     eWriteStream& operator<<(const QString& val);
     eWriteStream& operator<<(const QByteArray& val);
     eWriteStream& operator<<(SimpleBrushWrapper* const brush);
-    eWriteStream& operator<<(const FormatOptions &val);
+    eWriteStream& operator<<(const Friction::Core::FormatOptions &val);
 
     void writeFilePath(const QString& absPath);
 

--- a/src/core/ReadWrite/ewritestream.h
+++ b/src/core/ReadWrite/ewritestream.h
@@ -6,6 +6,8 @@
 
 #include "efuturepos.h"
 #include "../XML/runtimewriteid.h"
+#include "formatoptions.h"
+
 #include <functional>
 
 class SimpleBrushWrapper;
@@ -79,6 +81,7 @@ public:
     eWriteStream& operator<<(const QString& val);
     eWriteStream& operator<<(const QByteArray& val);
     eWriteStream& operator<<(SimpleBrushWrapper* const brush);
+    eWriteStream& operator<<(const FormatOptions &val);
 
     void writeFilePath(const QString& absPath);
 

--- a/src/core/formatoptions.h
+++ b/src/core/formatoptions.h
@@ -1,0 +1,51 @@
+/*
+#
+# Friction - https://friction.graphics
+#
+# Copyright (c) Friction contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See 'README.md' for more information.
+#
+*/
+
+#ifndef FORMATOPTIONS_H
+#define FORMATOPTIONS_H
+
+#include "core_global.h"
+
+#include <QList>
+#include <QString>
+
+enum CORE_EXPORT FormatType
+{
+    fTypeMeta,
+    fTypeFormat,
+    fTypeCodec
+};
+
+struct CORE_EXPORT FormatOption
+{
+    QString fKey;
+    QString fValue;
+    int fType;
+};
+
+struct CORE_EXPORT FormatOptions
+{
+    QList<FormatOption> fValues;
+};
+
+#endif // FORMATOPTIONS_H

--- a/src/core/formatoptions.h
+++ b/src/core/formatoptions.h
@@ -21,31 +21,44 @@
 #
 */
 
-#ifndef FORMATOPTIONS_H
-#define FORMATOPTIONS_H
+#ifndef FRICTION_FORMAT_OPTIONS_H
+#define FRICTION_FORMAT_OPTIONS_H
 
 #include "core_global.h"
 
 #include <QList>
-#include <QString>
+#include <QStringList>
 
-enum CORE_EXPORT FormatType
+namespace Friction
 {
-    fTypeMeta,
-    fTypeFormat,
-    fTypeCodec
-};
+    namespace Core
+    {
+        enum CORE_EXPORT FormatType
+        {
+            fTypeMeta,
+            fTypeFormat,
+            fTypeCodec
+        };
 
-struct CORE_EXPORT FormatOption
-{
-    QString fKey;
-    QString fValue;
-    int fType;
-};
+        struct CORE_EXPORT FormatOption
+        {
+            QString fKey;
+            QString fValue;
+            int fType;
+        };
 
-struct CORE_EXPORT FormatOptions
-{
-    QList<FormatOption> fValues;
-};
+        struct CORE_EXPORT FormatOptions
+        {
+            QList<FormatOption> fValues;
+        };
 
-#endif // FORMATOPTIONS_H
+        struct CORE_EXPORT FormatOptionsList
+        {
+            QStringList fTypes;
+            QStringList fKeys;
+            QStringList fValues;
+        };
+    }
+}
+
+#endif // FRICTION_FORMAT_OPTIONS_H

--- a/src/core/outputsettings.cpp
+++ b/src/core/outputsettings.cpp
@@ -24,6 +24,8 @@
 #include "ReadWrite/evformat.h"
 #include "appsupport.h"
 
+using namespace Friction::Core;
+
 QList<qsptr<OutputSettingsProfile>> OutputSettingsProfile::sOutputProfiles;
 bool OutputSettingsProfile::sOutputProfilesLoaded = false;
 
@@ -298,4 +300,16 @@ OutputSettingsProfile *OutputSettingsProfile::sGetByName(const QString &name)
         if (profile->getName() == name) { return profile.get(); }
     }
     return nullptr;
+}
+
+FormatOptions OutputSettingsProfile::toFormatOptions(const FormatOptionsList &list)
+{
+    FormatOptions options;
+    return options;
+}
+
+FormatOptionsList OutputSettingsProfile::toFormatOptionsList(const FormatOptions &options)
+{
+    FormatOptionsList list;
+    return list;
 }

--- a/src/core/outputsettings.cpp
+++ b/src/core/outputsettings.cpp
@@ -118,6 +118,7 @@ void OutputSettings::write(eWriteStream &dst) const
     dst.write(&fVideoPixelFormat, sizeof(AVPixelFormat));
     dst << fVideoBitrate;
     dst << fVideoProfile;
+    dst << fVideoOptions;
 
     dst << fAudioEnabled;
     dst << (fAudioCodec ? fAudioCodec->id : -1);
@@ -141,6 +142,9 @@ void OutputSettings::read(eReadStream &src)
     src >> fVideoBitrate;
     if (src.evFileVersion() >= EvFormat::codecProfile) {
         src >> fVideoProfile;
+    }
+    if (src.evFileVersion() >= EvFormat::formatOptions) {
+        src >> fVideoOptions;
     }
 
     src >> fAudioEnabled;

--- a/src/core/outputsettings.h
+++ b/src/core/outputsettings.h
@@ -29,6 +29,7 @@
 #include "Private/esettings.h"
 #include "smartPointers/ememory.h"
 #include "ReadWrite/basicreadwrite.h"
+#include "formatoptions.h"
 
 extern "C" {
     #include <libavcodec/avcodec.h>
@@ -56,6 +57,7 @@ struct CORE_EXPORT OutputSettings
     AVPixelFormat fVideoPixelFormat = AV_PIX_FMT_NONE;
     int fVideoBitrate = 0;
     int fVideoProfile = FF_PROFILE_UNKNOWN;
+    FormatOptions fVideoOptions;
 
     bool fAudioEnabled = false;
     const AVCodec *fAudioCodec = nullptr;

--- a/src/core/outputsettings.h
+++ b/src/core/outputsettings.h
@@ -94,6 +94,7 @@ public:
 
     static Friction::Core::FormatOptions toFormatOptions(const Friction::Core::FormatOptionsList &list);
     static Friction::Core::FormatOptionsList toFormatOptionsList(const Friction::Core::FormatOptions &options);
+    static bool isValidFormatOptionsList(const Friction::Core::FormatOptionsList &list);
 
 signals:
     void changed();

--- a/src/core/outputsettings.h
+++ b/src/core/outputsettings.h
@@ -57,7 +57,7 @@ struct CORE_EXPORT OutputSettings
     AVPixelFormat fVideoPixelFormat = AV_PIX_FMT_NONE;
     int fVideoBitrate = 0;
     int fVideoProfile = FF_PROFILE_UNKNOWN;
-    FormatOptions fVideoOptions;
+    Friction::Core::FormatOptions fVideoOptions;
 
     bool fAudioEnabled = false;
     const AVCodec *fAudioCodec = nullptr;
@@ -92,12 +92,15 @@ public:
     static QList<qsptr<OutputSettingsProfile>> sOutputProfiles;
     static bool sOutputProfilesLoaded;
 
+    static Friction::Core::FormatOptions toFormatOptions(const Friction::Core::FormatOptionsList &list);
+    static Friction::Core::FormatOptionsList toFormatOptionsList(const Friction::Core::FormatOptions &options);
+
 signals:
     void changed();
 
 private:
     QString mPath;
-    QString mName = "Untitled";
+    QString mName = tr("Untitled");
     OutputSettings mSettings;
 };
 

--- a/src/core/themesupport.cpp
+++ b/src/core/themesupport.cpp
@@ -167,6 +167,28 @@ const QColor ThemeSupport::getThemeColorTextDisabled(int alpha)
     return getQColor(112, 112, 113, alpha);
 }
 
+const QPalette ThemeSupport::getDefaultPalette(const QColor &highlight)
+{
+    QPalette palette;
+    palette.setColor(QPalette::Window, getThemeAlternateColor());
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Base, getThemeBaseColor());
+    palette.setColor(QPalette::AlternateBase, getThemeAlternateColor());
+    palette.setColor(QPalette::Link, Qt::white);
+    palette.setColor(QPalette::LinkVisited, Qt::white);
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::ToolTipBase, Qt::black);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::Button, getThemeBaseColor());
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::BrightText, Qt::white);
+    palette.setColor(QPalette::Highlight, highlight.isValid() ? highlight : getThemeHighlightColor());
+    palette.setColor(QPalette::HighlightedText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::Text, Qt::darkGray);
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::darkGray);
+    return palette;
+}
+
 const QPalette ThemeSupport::getDarkPalette(int alpha)
 {
     QPalette pal = QPalette();
@@ -223,25 +245,7 @@ void ThemeSupport::setupTheme(const int iconSize)
     QIcon::setThemeSearchPaths(QStringList() << QString::fromUtf8(":/icons"));
     QIcon::setThemeName(QString::fromUtf8("hicolor"));
     qApp->setStyle(QString::fromUtf8("fusion"));
-
-    QPalette palette;
-    palette.setColor(QPalette::Window, getThemeAlternateColor());
-    palette.setColor(QPalette::WindowText, Qt::white);
-    palette.setColor(QPalette::Base, getThemeBaseColor());
-    palette.setColor(QPalette::AlternateBase, getThemeAlternateColor());
-    palette.setColor(QPalette::Link, Qt::white);
-    palette.setColor(QPalette::LinkVisited, Qt::white);
-    palette.setColor(QPalette::ToolTipText, Qt::white);
-    palette.setColor(QPalette::ToolTipBase, Qt::black);
-    palette.setColor(QPalette::Text, Qt::white);
-    palette.setColor(QPalette::Button, getThemeBaseColor());
-    palette.setColor(QPalette::ButtonText, Qt::white);
-    palette.setColor(QPalette::BrightText, Qt::white);
-    palette.setColor(QPalette::Highlight, getThemeHighlightColor());
-    palette.setColor(QPalette::HighlightedText, Qt::white);
-    palette.setColor(QPalette::Disabled, QPalette::Text, Qt::darkGray);
-    palette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::darkGray);
-    qApp->setPalette(palette);
+    qApp->setPalette(getDefaultPalette());
     qApp->setStyleSheet(getThemeStyle(iconSize));
 }
 

--- a/src/core/themesupport.h
+++ b/src/core/themesupport.h
@@ -63,6 +63,7 @@ public:
     static const QColor getThemeColorGreenDark(int alpha = 255);
     static const QColor getThemeColorOrange(int alpha = 255);
     static const QColor getThemeColorTextDisabled(int alpha = 255);
+    static const QPalette getDefaultPalette(const QColor &highlight = QColor());
     static const QPalette getDarkPalette(int alpha = 255);
     static const QPalette getDarkerPalette(int alpha = 255);
     static const QPalette getNotSoDarkPalette(int alpha = 255);

--- a/src/core/videoencoder.cpp
+++ b/src/core/videoencoder.cpp
@@ -41,6 +41,8 @@
     } \
 }
 
+using namespace Friction::Core;
+
 VideoEncoder *VideoEncoder::sInstance = nullptr;
 
 VideoEncoder::VideoEncoder() {

--- a/src/core/videoencoder.cpp
+++ b/src/core/videoencoder.cpp
@@ -206,6 +206,27 @@ static void addVideoStream(OutputStream * const ost,
         c->profile = outSettings.fVideoProfile;
     }
 
+    for (const auto &opt : outSettings.fVideoOptions.fValues) {
+        switch (opt.fType) {
+        case FormatType::fTypeCodec:
+            av_opt_set(c->priv_data,
+                       opt.fKey.toStdString().c_str(),
+                       opt.fValue.toStdString().c_str(), 0);
+            break;
+        case FormatType::fTypeFormat:
+            av_opt_set(oc->priv_data,
+                       opt.fKey.toStdString().c_str(),
+                       opt.fValue.toStdString().c_str(), 0);
+            break;
+        case FormatType::fTypeMeta:
+            av_dict_set(&oc->metadata,
+                        opt.fKey.toStdString().c_str(),
+                        opt.fValue.toStdString().c_str(), 0);
+            break;
+        default:;
+        }
+    }
+
     c->gop_size      = 12; /* emit one intra frame every twelve frames at most */
     c->pix_fmt       = outSettings.fVideoPixelFormat;//RGBA;
     if(c->codec_id == AV_CODEC_ID_MPEG2VIDEO) {


### PR DESCRIPTION
This PR adds support for FFmpeg options to the renderer.

You can now add key/value for meta, codec and format.

What is supported and works depends on various variables, check the FFmpeg documentation:

* https://www.ffmpeg.org/doxygen/3.2/group__metadata__api.html
* https://trac.ffmpeg.org/wiki/Encode/H.264
* https://trac.ffmpeg.org/wiki/Encode/H.265
* https://trac.ffmpeg.org/wiki/Encode/VFX

Fixes #241 

![Screenshot from 2024-09-07 21-27-25](https://github.com/user-attachments/assets/dfd0c3ce-2ad9-46c3-8d99-128734177b41)
