### PR TITLE
Switch macOS popup windows to Qt::Tool

### DIFF
--- a/src/app/GUI/Expressions/expressiondialog.cpp
+++ b/src/app/GUI/Expressions/expressiondialog.cpp
@@ -299,7 +299,7 @@ ExpressionDialog::ExpressionDialog(QrealAnimator* const target,
 {
     setWindowTitle(tr("Expression %1").arg(target->prp_getName()));
 #ifdef Q_OS_MAC
-    setWindowFlag(Qt::WindowStaysOnTopHint);
+    setWindowFlag(Qt::Tool);
 #endif
 
     const auto windowLayout = new QVBoxLayout(this);

--- a/src/ui/dialogs/adjustscenedialog.cpp
+++ b/src/ui/dialogs/adjustscenedialog.cpp
@@ -45,6 +45,9 @@ AdjustSceneDialog::AdjustSceneDialog(Canvas *scene,
 
     setMinimumWidth(400);
     setWindowTitle(tr("Adjust scene to clip?"));
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
 
     const auto mLayout = new QVBoxLayout(this);
 

--- a/src/ui/dialogs/applyexpressiondialog.cpp
+++ b/src/ui/dialogs/applyexpressiondialog.cpp
@@ -37,6 +37,9 @@ ApplyExpressionDialog::ApplyExpressionDialog(QrealAnimator* const target,
                                              QWidget * const parent) :
     QDialog(parent), mTarget(target) {
     setWindowTitle("Apply Expression " + target->prp_getName());
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     const auto mainLayout = new QVBoxLayout(this);

--- a/src/ui/dialogs/commandpalette.cpp
+++ b/src/ui/dialogs/commandpalette.cpp
@@ -43,11 +43,14 @@ CommandPalette::CommandPalette(Document& document,
     , mSuggestions(nullptr)
     , mHistoryCounter(-1)
 {
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint
+
 #ifdef Q_OS_MAC
-                   | Qt::WindowStaysOnTopHint
+    setWindowFlags(Qt::Tool
+#else
+    setWindowFlags(Qt::Window
 #endif
-                   );
+    | Qt::FramelessWindowHint);
+
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_TransparentForMouseEvents);

--- a/src/ui/dialogs/durationrectsettingsdialog.cpp
+++ b/src/ui/dialogs/durationrectsettingsdialog.cpp
@@ -31,6 +31,9 @@
 DurationRectSettingsDialog::DurationRectSettingsDialog(
         DurationRectangle* const target, QWidget *parent) :
     QDialog(parent), mTarget(target) {
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
     const auto values = mTarget->getValues();
     const auto mainLayout = new QVBoxLayout(this);
     const auto twoColumnLayout = new TwoColumnLayout();

--- a/src/ui/dialogs/exportsvgdialog.cpp
+++ b/src/ui/dialogs/exportsvgdialog.cpp
@@ -46,6 +46,9 @@ ExportSvgDialog::ExportSvgDialog(QWidget* const parent,
     : QDialog(parent)
 {
     setWindowTitle(tr("Export SVG"));
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
 
     const auto settingsLayout = new QVBoxLayout();
 

--- a/src/ui/dialogs/markereditordialog.cpp
+++ b/src/ui/dialogs/markereditordialog.cpp
@@ -38,7 +38,7 @@ MarkerEditorDialog::MarkerEditorDialog(Canvas *scene,
 {
     setWindowTitle(tr("Marker Editor"));
 #ifdef Q_OS_MAC
-    setWindowFlag(Qt::WindowStaysOnTopHint);
+    setWindowFlag(Qt::Tool);
 #endif
 
     const auto lay = new QVBoxLayout(this);

--- a/src/ui/dialogs/qrealpointvaluedialog.cpp
+++ b/src/ui/dialogs/qrealpointvaluedialog.cpp
@@ -30,6 +30,9 @@ QrealPointValueDialog::QrealPointValueDialog(QrealPoint *point,
                                              QWidget *parent) :
     QDialog(parent) {
     setWindowTitle("Edit key");
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
     mMainLayout = new QVBoxLayout(this);
     setLayout(mMainLayout);
 

--- a/src/ui/dialogs/renderoutputwidget.cpp
+++ b/src/ui/dialogs/renderoutputwidget.cpp
@@ -34,6 +34,9 @@
 RenderOutputWidget::RenderOutputWidget(const int canvasWidth,
                                        const int canvasHeight,
                                        QWidget *parent) : QDialog(parent) {
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
     mCanvasWidth = canvasWidth;
     mCanvasHeight = canvasHeight;
 

--- a/src/ui/dialogs/scenesettingsdialog.cpp
+++ b/src/ui/dialogs/scenesettingsdialog.cpp
@@ -74,6 +74,9 @@ SceneSettingsDialog::SceneSettingsDialog(const QString &name,
     mEnableResolutionPresetsAuto = presetsResolutionSettings.second;
 
     setWindowTitle(tr("Scene Properties"));
+#ifdef Q_OS_MAC
+    setWindowFlag(Qt::Tool);
+#endif
     mMainLayout = new QVBoxLayout(this);
     mMainLayout->setSizeConstraint(QLayout::SetFixedSize);
 


### PR DESCRIPTION
This way they stay on top but just inside Friction limits, if using `Qt::WindowStaysOnTopHint` the popup stays on top of every window open on your OS (not desired behavior):

<img width="954" alt="Screenshot 2024-11-14 at 17 19 27" src="https://github.com/user-attachments/assets/a308cf0d-4f47-440e-aa8e-79d15a6bec79">

If using `Qt::Tool` the popup stays on top while in the app, when going out of it it hides but when going back to Friction it stays still on top:

<img width="918" alt="Screenshot 2024-11-14 at 17 21 16" src="https://github.com/user-attachments/assets/e2a31a05-263a-4096-9135-d199dd876fe9">

I tested it here and it works perfectly, I just applied it to macOS and applied it to all dialogs I found... maybe I'm missing more...

Cheers