### PR TITLE
QMessageBox buttons

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1475,7 +1475,7 @@ bool MainWindow::askForSaving() {
         QString file = info.baseName();
         if (file.isEmpty()) { file = tr("Untitled"); }
 
-        const QString question = tr("Save changes to document \"%1\"?",
+        const QString question = tr("Save changes to document \"%1\"?          ", // empty spaces at the end of the question to make room for buttons
                                     "AskSaveDialog_Question");
         const QString questionWithTarget = question.arg(file);
         const QString closeNoSave =  tr("Close without saving",

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -602,3 +602,9 @@ Friction--Ui--ToolBar::separator:vertical {
 Friction--Ui--ToolBar::separator:horizontal {
     width: 1px;
 }
+
+QMessageBox QPushButton {
+    min-width: 50px;
+    padding-left: 6px;
+    padding-right: 6px;
+}


### PR DESCRIPTION
These QMessageBoxes are kind of simples and lacked some style, I improved them as follows:

![qmessagebox2](https://github.com/user-attachments/assets/66c60c17-2104-4dbf-b13c-2f1d19c505ec)
![qmessagebox1](https://github.com/user-attachments/assets/2db88191-ffe6-466f-b6c9-5ff322a6ac7b)

I need to add a little hack as I wanted to make the QMessageBox of the "Save changes to document..." window wider and I didn't want to touch much code so, after trying some styling commands I ended up by just adding a bunch of spaces into the QLabel... it's not so smart but let me know if you prefer another approach.

Cheers