### PR TITLE
SVG follow path with auto rotation and keypoints

### DIFF
--- a/src/core/Animators/graphanimator.cpp
+++ b/src/core/Animators/graphanimator.cpp
@@ -558,7 +558,7 @@ void GraphAnimator::graph_saveSVG(SvgExporter& exp,
             anim.setAttribute("attributeName", attrName);
             if (!type.isEmpty()) { anim.setAttribute("type", type);  }
         } else {
-            //if (motionRotate) { anim.setAttribute("rotate", "auto"); }
+            if (motionRotate) { anim.setAttribute("rotate", "auto"); }
             if (!motionPath.isEmpty()) {
                 auto mpath = exp.createElement("mpath");
                 mpath.setAttribute("href", QString("#%1").arg(AppSupport::filterId(motionPath)));

--- a/src/core/Animators/graphanimator.cpp
+++ b/src/core/Animators/graphanimator.cpp
@@ -636,6 +636,9 @@ void GraphAnimator::graph_saveSVG(SvgExporter& exp,
 
         anim.setAttribute("calcMode", "spline");
         anim.setAttribute("values", values.join(';'));
+        if (motion) {
+            anim.setAttribute("keyPoints", values.join(';'));
+        }
         anim.setAttribute("keyTimes", keyTimes.join(';'));
         anim.setAttribute("keySplines", keySplines.join(';'));
 


### PR DESCRIPTION
I've been working this weekend in the "SVG follow path" feature as [I find it pretty important](https://github.com/orgs/friction2d/discussions/326), I'm posting there all my findings but here I'm adding the final results.

Summing it all up:

- your `rotate="auto"` implementation works, but only in a specific scenario that makes sense to me. Maybe it is that Friction let's you do things so flexible that, as in this case, could look like it's not working. So, if the path or group you want to make follow a path has 'translation', 'rotation', 'scale' and 'pivot set to 0 while connected to a path to follow, the animation works fine. Fixing this could be easier for you... for me go further into the code to "fix" or to make it easier for users is almost impossible.
- I added `keyPoints` attribute to `<animateMotion>` and used the "values" and now keyframing the "complete" variable of the "follow path" effect works properly.

Here is a working example and the `.friction` project:
| project | _________ exported SVG _________ |
|:--------------:|:--------------:|
| [example.friction.zip](https://github.com/user-attachments/files/17799104/example.friction.zip) | ![example](https://github.com/user-attachments/assets/b619481b-590b-49fe-b1a7-4247bdbc0812) |





Let me know what do you think and what further work do you think it is necessary.

If you feel like merging this feature as it is now (with this fix) then I could do a tutorial for users so that they understand the  settings they need to follow in order to properly export animated SVGs with the "follow path" effect and `rotate` set to "auto".

Cheers