### PR TITLE
Adding offset parameter to sub-path effect

### DIFF
--- a/src/core/PathEffects/subpatheffect.cpp
+++ b/src/core/PathEffects/subpatheffect.cpp
@@ -41,9 +41,14 @@ SubPathEffect::SubPathEffect() :
     mMax->setValueRange(-999, 999);
     mMax->setCurrentBaseValue(100);
 
+    mOffset = enve::make_shared<QrealAnimator>("offset");
+    mOffset->setValueRange(-999, 999);
+    mOffset->setCurrentBaseValue(0);
+
     ca_addChild(mPathWise);
     ca_addChild(mMin);
     ca_addChild(mMax);
+    ca_addChild(mOffset);
 }
 
 class SubPathEffectCaller : public PathEffectCaller {
@@ -121,7 +126,9 @@ void SubPathEffectCaller::apply(SkPath &path) {
 stdsptr<PathEffectCaller> SubPathEffect::getEffectCaller(
         const qreal relFrame, const qreal influence) const {
     const bool pathWise = mPathWise->getValue();
-    const qreal minFrac = mMin->getEffectiveValue(relFrame)*0.01*influence;
-    const qreal maxFrac = mMax->getEffectiveValue(relFrame)*0.01*influence + 1 - influence;
+    const qreal offset = mOffset->getEffectiveValue(relFrame);
+    const qreal minFrac = (mMin->getEffectiveValue(relFrame) + offset) * 0.01 * influence;
+    const qreal maxFrac = (mMax->getEffectiveValue(relFrame) + offset) * 0.01 * influence + 1 - influence;
+
     return enve::make_shared<SubPathEffectCaller>(pathWise, minFrac, maxFrac);
 }

--- a/src/core/PathEffects/subpatheffect.h
+++ b/src/core/PathEffects/subpatheffect.h
@@ -38,6 +38,7 @@ private:
     qsptr<BoolProperty> mPathWise;
     qsptr<QrealAnimator> mMin;
     qsptr<QrealAnimator> mMax;
+    qsptr<QrealAnimator> mOffset;
 };
 
 #endif // SUBPATHEFFECT_H


### PR DESCRIPTION
When working with sub-path effect, it's very handy to have an offset parameter to easily animate the trimmed path.
Other software usually have this feature:
After Effects: https://www.youtube.com/watch?v=FovNvDpVCR4
Lottie: https://www.youtube.com/watch?v=968xhinfrYU

And here a working example of the feature in Friction:

https://github.com/user-attachments/assets/e9458d68-2ad8-4f41-8f62-3f3b5a8cd206

The only odd behavior I found is that opening old projects where "sub-path" effect is used, make Friction to crash... any idea how to solve it?

Do you know if this feature has connections with other ones that I didn't think of and could make Friction to crash or not to work properly.

Cheers