### PR TITLE
Markers fixes and polish

### DIFF
--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -552,6 +552,7 @@ void Canvas::moveMarkerFrame(const int markerFrame,
     if (index >= 0) {
         mMarkers.at(index).frame = newFrame;
         emit newFrameRange(mRange);
+        emit markersChanged();
     }
 }
 

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -477,6 +477,7 @@ void Canvas::setMarker(const QString &title,
 void Canvas::setMarker(const int frame)
 {
     setMarker(QString::number(mMarkers.size()), frame);
+    emit markersChanged();
 }
 
 void Canvas::setMarkerEnabled(const int frame,
@@ -578,6 +579,7 @@ const std::vector<FrameMarker> Canvas::getMarkers()
 void Canvas::clearMarkers()
 {
     mMarkers.clear();
+    emit markersChanged();
     emit requestUpdate();
 }
 

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -456,6 +456,7 @@ signals:
     void openApplyExpressionDialog(QrealAnimator* const target);
     void currentPickedColor(const QColor &color);
     void currentHoverColor(const QColor &color);
+    void markersChanged();
 
 public:
     void makePointCtrlsSymmetric();

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -80,8 +80,14 @@ void MarkerEditor::setup()
 
     connect(addButton, &QPushButton::clicked,
             this, [this]() {
-        auto item = new QTreeWidgetItem(mTree);
         const int frame = mScene ? mScene->getCurrentFrame() : 0;
+        for (int i = 0; i < mTree->topLevelItemCount(); ++i) {
+            auto existingItem = mTree->topLevelItem(i);
+            if (existingItem && existingItem->data(0, Qt::UserRole).toInt() == frame) {
+                return;
+            }
+        }
+        auto item = new QTreeWidgetItem(mTree);
         mTree->blockSignals(true);
         item->setText(1, QString::number(frame));
         item->setText(0, QString::number(frame));

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -41,6 +41,10 @@ MarkerEditor::MarkerEditor(Canvas *scene,
     lay->addWidget(mTree);
     setup();
     populate();
+        
+    if (mScene) {
+        connect(mScene, &Canvas::markersChanged, this, &MarkerEditor::populate);
+    }
 }
 
 void MarkerEditor::setup()

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -82,9 +82,11 @@ void MarkerEditor::setup()
             this, [this]() {
         auto item = new QTreeWidgetItem(mTree);
         const int frame = mScene ? mScene->getCurrentFrame() : 0;
+        mTree->blockSignals(true);
         item->setText(1, QString::number(frame));
         item->setText(0, QString::number(frame));
         item->setData(0, Qt::UserRole, frame);
+        mTree->blockSignals(false);
         item->setCheckState(0, Qt::Checked);
         item->setFlags(item->flags() | Qt::ItemIsEditable);
         mTree->addTopLevelItem(item);


### PR DESCRIPTION
I have polished the Markers editor:

- fixed the problem of "marker at frame 0 being deleted when using addButton".
It solves https://github.com/friction2d/friction/issues/272#issuecomment-2473005050
- limited the creation of fake markers at same frame
- synced the marker editor list if it's open and you decide to create, move or delete markers directly from the timeline

I hope everything is fine
=)

Cheers