### PR TITLE
New null object type

### DIFF
--- a/src/core/Boxes/nullobject.cpp
+++ b/src/core/Boxes/nullobject.cpp
@@ -30,7 +30,7 @@
 
 class NullObjectType : public ComboBoxProperty {
     enum class Type {
-        square, circle, triangle
+        square, circle, crosshair, triangle
     };
 public:
     NullObjectType(ColorAnimator* const color,
@@ -53,6 +53,7 @@ NullObjectType::NullObjectType(ColorAnimator* const color,
                                QrealAnimator* const size) :
     ComboBoxProperty("type", QStringList()  << "square" <<
                                                "circle" <<
+                                               "crosshair" <<
                                                "triangle"),
     mColor(color), mSize(size) {
     prp_setDrawingOnCanvasEnabled(true);
@@ -113,6 +114,24 @@ void NullObjectType::updatePath() {
         mCurrentPath.moveTo(ten, -ten);
         mCurrentPath.lineTo(-ten, ten);
         break;
+    case Type::crosshair: {
+        const qreal circleRadius = ten * 7/8;
+        mCurrentPath.addCircle(0, 0, circleRadius);
+        const qreal lineLength = 2 * ten / 8;
+        mCurrentPath.moveTo(-circleRadius - lineLength, 0);
+        mCurrentPath.lineTo(-circleRadius + lineLength, 0);
+        mCurrentPath.moveTo(circleRadius - lineLength, 0);
+        mCurrentPath.lineTo(circleRadius + lineLength, 0);
+        mCurrentPath.moveTo(0, -circleRadius + lineLength);
+        mCurrentPath.lineTo(0, -circleRadius - lineLength);
+        mCurrentPath.moveTo(0, circleRadius + lineLength);
+        mCurrentPath.lineTo(0, circleRadius - lineLength);
+        mCurrentPath.moveTo(lineLength/2, 0);
+        mCurrentPath.lineTo(-lineLength/2, 0);
+        mCurrentPath.moveTo(0, + lineLength/2);
+        mCurrentPath.lineTo(0, - lineLength/2);
+        break;
+        }
     case Type::triangle:
         const qreal a = 3*ten/sqrt(3);
         const qreal h = ten + a*sqrt(3)/6;
@@ -140,6 +159,10 @@ bool NullObjectType::relPointInsidePath(const QPointF& relPos) {
         QRectF rect(-ten, -ten, 2*ten, 2*ten);
         return rect.contains(relPos);
     } case Type::circle: {
+        QPainterPath path;
+        path.addEllipse({0., 0.}, ten, ten);
+        return path.contains(relPos);
+    } case Type::crosshair: {
         QPainterPath path;
         path.addEllipse({0., 0.}, ten, ten);
         return path.contains(relPos);

--- a/src/core/Boxes/nullobject.cpp
+++ b/src/core/Boxes/nullobject.cpp
@@ -30,7 +30,7 @@
 
 class NullObjectType : public ComboBoxProperty {
     enum class Type {
-        square, circle, crosshair, triangle
+        square, circle, triangle, crosshair
     };
 public:
     NullObjectType(ColorAnimator* const color,
@@ -53,8 +53,8 @@ NullObjectType::NullObjectType(ColorAnimator* const color,
                                QrealAnimator* const size) :
     ComboBoxProperty("type", QStringList()  << "square" <<
                                                "circle" <<
-                                               "crosshair" <<
-                                               "triangle"),
+                                               "triangle" <<
+                                               "crosshair"),
     mColor(color), mSize(size) {
     prp_setDrawingOnCanvasEnabled(true);
 

--- a/src/core/Boxes/nullobject.cpp
+++ b/src/core/Boxes/nullobject.cpp
@@ -60,6 +60,8 @@ NullObjectType::NullObjectType(ColorAnimator* const color,
 
     connect(this, &ComboBoxProperty::prp_currentFrameChanged,
             this, &NullObjectType::updatePath);
+    connect(this, &ComboBoxProperty::prp_pathChanged,
+            this, &NullObjectType::updatePath);
     connect(mSize, &QrealAnimator::prp_currentFrameChanged,
             this, &NullObjectType::updatePath);
     updatePath();


### PR DESCRIPTION
Playing with null objects felt like adding a new one "crosshair":

<img width="538" alt="Screenshot 2024-11-22 at 23 35 16" src="https://github.com/user-attachments/assets/f2ec6396-051b-4722-b0a0-c14a03d1d49e">

I hope you like it.

I tried opening a file with the new target on an "old Friction build" and it opened it. It didn't show up any icon as its index didn't exist on that version but it just left it as a "blank type". Manually you can then change it to any existing type and "problem solved"... I mean, it's compatible.

Cheers