### PR TITLE
Markers editor buttons

### DIFF
--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -552,6 +552,7 @@ void Canvas::moveMarkerFrame(const int markerFrame,
     if (index >= 0) {
         mMarkers.at(index).frame = newFrame;
         emit newFrameRange(mRange);
+        emit markersChanged();
     }
 }
 

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -477,6 +477,7 @@ void Canvas::setMarker(const QString &title,
 void Canvas::setMarker(const int frame)
 {
     setMarker(QString::number(mMarkers.size()), frame);
+    emit markersChanged();
 }
 
 void Canvas::setMarkerEnabled(const int frame,
@@ -578,6 +579,7 @@ const std::vector<FrameMarker> Canvas::getMarkers()
 void Canvas::clearMarkers()
 {
     mMarkers.clear();
+    emit markersChanged();
     emit requestUpdate();
 }
 

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -456,6 +456,7 @@ signals:
     void openApplyExpressionDialog(QrealAnimator* const target);
     void currentPickedColor(const QColor &color);
     void currentHoverColor(const QColor &color);
+    void markersChanged();
 
 public:
     void makePointCtrlsSymmetric();

--- a/src/ui/dialogs/markereditordialog.cpp
+++ b/src/ui/dialogs/markereditordialog.cpp
@@ -50,6 +50,10 @@ MarkerEditorDialog::MarkerEditorDialog(Canvas *scene,
     const auto clearButton = new QPushButton(QIcon::fromTheme("trash"), tr(""));
     const auto closeButton = new QPushButton(QIcon::fromTheme("close"), tr("Close"));
 
+    addButton->setToolTip(tr("Add a new marker"));
+    remButton->setToolTip(tr("Remove the selected marker from the list"));
+    clearButton->setToolTip(tr("Clear all markers"));
+
     addButton->setFocusPolicy(Qt::NoFocus);
     remButton->setFocusPolicy(Qt::NoFocus);
     clearButton->setFocusPolicy(Qt::NoFocus);

--- a/src/ui/dialogs/markereditordialog.cpp
+++ b/src/ui/dialogs/markereditordialog.cpp
@@ -44,15 +44,28 @@ MarkerEditorDialog::MarkerEditorDialog(Canvas *scene,
     const auto lay = new QVBoxLayout(this);
     const auto editor = new MarkerEditor(scene, this);
     const auto footer = new QHBoxLayout();
-    const auto button = new QPushButton(QIcon::fromTheme("close"),
-                                        tr("Close"));
 
-    button->setFocusPolicy(Qt::NoFocus);
-    connect(button, &QPushButton::clicked,
-            this, &QDialog::close);
+    const auto addButton = new QPushButton(QIcon::fromTheme("plus"), tr(""));
+    const auto remButton = new QPushButton(QIcon::fromTheme("minus"), tr(""));
+    const auto clearButton = new QPushButton(QIcon::fromTheme("trash"), tr(""));
+    const auto closeButton = new QPushButton(QIcon::fromTheme("close"), tr("Close"));
 
+    addButton->setFocusPolicy(Qt::NoFocus);
+    remButton->setFocusPolicy(Qt::NoFocus);
+    clearButton->setFocusPolicy(Qt::NoFocus);
+    closeButton->setFocusPolicy(Qt::StrongFocus);
+    closeButton->setFocus();
+
+    connect(addButton, &QPushButton::clicked, editor, &MarkerEditor::addMarker);
+    connect(remButton, &QPushButton::clicked, editor, &MarkerEditor::removeMarker);
+    connect(clearButton, &QPushButton::clicked, editor, &MarkerEditor::clearMarkers);
+    connect(closeButton, &QPushButton::clicked, this, &QDialog::close);
+
+    footer->addWidget(addButton);
+    footer->addWidget(remButton);
+    footer->addWidget(clearButton);
     footer->addStretch();
-    footer->addWidget(button);
+    footer->addWidget(closeButton);
 
     lay->addWidget(editor);
     lay->addLayout(footer);

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -80,8 +80,14 @@ void MarkerEditor::setup()
 
     connect(addButton, &QPushButton::clicked,
             this, [this]() {
-        auto item = new QTreeWidgetItem(mTree);
         const int frame = mScene ? mScene->getCurrentFrame() : 0;
+        for (int i = 0; i < mTree->topLevelItemCount(); ++i) {
+            auto existingItem = mTree->topLevelItem(i);
+            if (existingItem && existingItem->data(0, Qt::UserRole).toInt() == frame) {
+                return;
+            }
+        }
+        auto item = new QTreeWidgetItem(mTree);
         mTree->blockSignals(true);
         item->setText(1, QString::number(frame));
         item->setText(0, QString::number(frame));

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -41,6 +41,10 @@ MarkerEditor::MarkerEditor(Canvas *scene,
     lay->addWidget(mTree);
     setup();
     populate();
+        
+    if (mScene) {
+        connect(mScene, &Canvas::markersChanged, this, &MarkerEditor::populate);
+    }
 }
 
 void MarkerEditor::setup()

--- a/src/ui/widgets/markereditor.cpp
+++ b/src/ui/widgets/markereditor.cpp
@@ -82,9 +82,11 @@ void MarkerEditor::setup()
             this, [this]() {
         auto item = new QTreeWidgetItem(mTree);
         const int frame = mScene ? mScene->getCurrentFrame() : 0;
+        mTree->blockSignals(true);
         item->setText(1, QString::number(frame));
         item->setText(0, QString::number(frame));
         item->setData(0, Qt::UserRole, frame);
+        mTree->blockSignals(false);
         item->setCheckState(0, Qt::Checked);
         item->setFlags(item->flags() | Qt::ItemIsEditable);
         mTree->addTopLevelItem(item);

--- a/src/ui/widgets/markereditor.h
+++ b/src/ui/widgets/markereditor.h
@@ -42,6 +42,9 @@ namespace Friction
         public:
             explicit MarkerEditor(Canvas *scene = nullptr,
                                   QWidget *parent = nullptr);
+            void addMarker();
+            void removeMarker();
+            void clearMarkers(); 
 
         private:
             Canvas *mScene;


### PR DESCRIPTION
Following the work on https://github.com/friction2d/friction/pull/336 here is what I think a better way to interact with the Markers editor window:

<img width="443" alt="markers" src="https://github.com/user-attachments/assets/ffe07adc-b14f-445d-bf09-628d1bcd44b4">

- Changed the buttons to the same row of the "close" button
- added a "clear all" option
- added tooltips for "+", "-", and "clear" buttons

