### PR TITLE
Framerate fixes

### DIFF
--- a/src/core/Boxes/videobox.cpp
+++ b/src/core/Boxes/videobox.cpp
@@ -66,6 +66,7 @@ VideoBox::VideoBox() : AnimationBox("Video", eBoxType::video),
 
     connect(this, &eBoxOrSound::parentChanged,
             mSound.get(), &eBoxOrSound::setParentGroup);
+    connect(this, &eBoxOrSound::parentChanged, this, &VideoBox::setCorrectFps);
 }
 
 void VideoBox::fileHandlerConnector(ConnContext &conn, VideoFileHandler *obj) {

--- a/src/core/Boxes/videobox.h
+++ b/src/core/Boxes/videobox.h
@@ -31,7 +31,6 @@
 #include "FileCacheHandlers/videocachehandler.h"
 #include "canvas.h"
 
-#include <QInputDialog>
 class eVideoSound;
 
 class CORE_EXPORT VideoBox : public AnimationBox {
@@ -75,7 +74,6 @@ private:
         
         auto const dataHandler = mFileHandler->getFrameHandler();
         if (!dataHandler) { return; }
-        dataHandler->mFrameHandlers.length();
         qsptr<VideoFrameHandler> vframeHandler;
         vframeHandler = enve::make_shared<VideoFrameHandler>(dataHandler);
 

--- a/src/core/FileCacheHandlers/videocachehandler.h
+++ b/src/core/FileCacheHandlers/videocachehandler.h
@@ -66,6 +66,7 @@ private:
     qreal mFrameFps = 0;
     int mFrameWidth = 0;
     int mFrameHeight = 0;
+public:
     QList<VideoFrameHandler*> mFrameHandlers;
     QList<int> mFramesBeingLoaded;
     QList<stdsptr<VideoFrameLoader>> mFrameLoaders;
@@ -103,6 +104,7 @@ private:
     std::set<int> mNeededFrames;
 
     VideoDataHandler* const mDataHandler;
+public:
     stdsptr<VideoStreamsData> mVideoStreamsData;
 };
 #include "CacheHandlers/soundcachehandler.h"


### PR DESCRIPTION
Fixes #322, adds a signal during videobox initialization to adjust video framerate from scene framerate. Gets applied on asset import (drag and drop/ import menu) and on project load so we might want to bump up the project version, since along changing the video framerate to match the scene framerate it also adjusts the video length, which might be a breaking change (then again we were handling it incorrectly before so I don't think it should be allowed if possible, you let me know).

## Problems // Limitations
- Changing scene framerate doesn't change the framerate of the videos immediately, you'd have to reopen the project after saving (reloading the media doesn't fix it).
- What I think is a bigger issue is the fact that videos only ever adjust to one framerate, that is, you can have multiple scenes in one project, but the videos will only adjust to the scene they're loaded into, which means the issue we had before persists or gets worse when we change to a scene with different framerate. 
- This does not fix the issue for image sequences, but I can look into it.

The first and third problems seem easy enough to fix but the second one is kind of major and might need some general tweaking of the way the editor handles scenes and assets, so I'm not entirely sure how to approach it. Maybe it's not a big enough problem to look into it because we realistically don't know how much people would be working on scenes with different framerates in the same project but I still think it's important.

I'd appreciate any help to get this to a better state... (For some reason I'm unable to debug the project, that's why changes on my end take a while).

Here's some example videos I made (on friction) to better test the framerate changes, they sync on this branch but do not on the original.


https://github.com/user-attachments/assets/ed157e8e-9a90-4c58-9197-41db0a56895a

https://github.com/user-attachments/assets/216d80e2-8320-46e4-bda6-37c688e6cda4

https://github.com/user-attachments/assets/a439c9e5-3aac-44f3-b3a4-9523adab85f9


