### PR TITLE
Pivot alignment

### DIFF
--- a/src/app/GUI/extraactions.cpp
+++ b/src/app/GUI/extraactions.cpp
@@ -161,7 +161,7 @@ void MainWindow::setupMenuExtras()
     }
     // align
     {
-        const int alignTotal = 28;
+        const int alignTotal = 40;
 
         const QString alignTextDefault = tr("Align %1 %2 Relative to %3");
         const QString alignGeometry = tr("Geometry");
@@ -242,19 +242,11 @@ void MainWindow::setupMenuExtras()
                 align = Qt::AlignHCenter;
                 break;
             case 4: // Align Left - Geometry Relative to Scene -----------------------------------------------------------------------------------
-                // alignString = alignLeft;
-                // pivotString = alignGeometry;
-                // relString = alignScene;
-                // pivot = AlignPivot::geometry;   
-                // rel = AlignRelativeTo::scene;
-                // iconString = alignLeftIcon;
-                // alignBoth = false;
-                // align = Qt::AlignLeft;
                 alignString = alignLeft;
                 pivotString = alignGeometry;
                 relString = alignScene;
                 pivot = AlignPivot::geometry;
-                rel = AlignRelativeTo::itself;
+                rel = AlignRelativeTo::scene;
                 iconString = alignLeftIcon;
                 alignBoth = false;
                 align = Qt::AlignLeft;
@@ -488,6 +480,126 @@ void MainWindow::setupMenuExtras()
                 iconString = alignVCenterIcon;
                 alignBoth = false;
                 align = Qt::AlignVCenter;
+                break;
+            case 28:  // Pivot alignment to Bounding Box - VCenter -----------------------------------------------------------------------------------
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignVCenter;
+                break;
+            case 29:  // Pivot alignment to Bounding Box - HCenter
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignHCenter;
+                break;
+            case 30:  // Pivot alignment to Bounding Box - Left
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignLeft;
+                break;
+            case 31:  // Pivot alignment to Bounding Box - Right
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignRight;
+                break;
+            case 32:  // Pivot alignment to Bounding Box - Top
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignTop;
+                break;
+            case 33:  // Pivot alignment to Bounding Box - Bottom
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::boundingBox;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignBottom;
+                break;
+            case 34:  // Pivot alignment to Scene - VCenter -----------------------------------------------------------------------------------
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignVCenter;
+                break;
+            case 35:  // Pivot alignment to Scene - HCenter
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignHCenter;
+                break;
+            case 36:  // Pivot alignment to Scene - Left
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignLeft;
+                break;
+            case 37:  // Pivot alignment to Scene - Right
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignRight;
+                break;
+            case 38:  // Pivot alignment to Scene - Top
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignTop;
+                break;
+            case 39:  // Pivot alignment to Scene - Bottom
+                alignString = alignVCenter;
+                pivotString = alignPivot;
+                relString = alignLast;
+                pivot = AlignPivot::pivot2;
+                rel = AlignRelativeTo::scene;
+                iconString = alignVCenterIcon;
+                alignBoth = false;
+                align = Qt::AlignBottom;
                 break;
             default:
                 return;

--- a/src/app/GUI/extraactions.cpp
+++ b/src/app/GUI/extraactions.cpp
@@ -242,11 +242,19 @@ void MainWindow::setupMenuExtras()
                 align = Qt::AlignHCenter;
                 break;
             case 4: // Align Left - Geometry Relative to Scene -----------------------------------------------------------------------------------
+                // alignString = alignLeft;
+                // pivotString = alignGeometry;
+                // relString = alignScene;
+                // pivot = AlignPivot::geometry;   
+                // rel = AlignRelativeTo::scene;
+                // iconString = alignLeftIcon;
+                // alignBoth = false;
+                // align = Qt::AlignLeft;
                 alignString = alignLeft;
                 pivotString = alignGeometry;
                 relString = alignScene;
                 pivot = AlignPivot::geometry;
-                rel = AlignRelativeTo::scene;
+                rel = AlignRelativeTo::itself;
                 iconString = alignLeftIcon;
                 alignBoth = false;
                 align = Qt::AlignLeft;

--- a/src/app/GUI/extraactions.cpp
+++ b/src/app/GUI/extraactions.cpp
@@ -485,7 +485,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -495,7 +495,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -505,7 +505,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -515,7 +515,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -525,7 +525,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -535,7 +535,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::boundingBox;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -545,7 +545,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -555,7 +555,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -565,7 +565,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -575,7 +575,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -585,7 +585,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;
@@ -595,7 +595,7 @@ void MainWindow::setupMenuExtras()
                 alignString = alignVCenter;
                 pivotString = alignPivot;
                 relString = alignLast;
-                pivot = AlignPivot::pivot2;
+                pivot = AlignPivot::pivotItself;
                 rel = AlignRelativeTo::scene;
                 iconString = alignVCenterIcon;
                 alignBoth = false;

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -865,7 +865,7 @@ void BoundingBox::alignPivot(const Qt::Alignment align, const QRectF& to) {
     alignGeometry(QRectF(pivot, pivot), align, to);
 }
 
-void BoundingBox::alignPivot2(const Qt::Alignment align,
+void BoundingBox::alignPivotItself(const Qt::Alignment align,
                               const QRectF& to,
                               const AlignRelativeTo relativeTo,
                               const QPointF lastPivotAbsPos) {

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -881,10 +881,6 @@ void BoundingBox::alignPivotItself(const Qt::Alignment align,
     
     QPointF center = getRelCenterPosition();
 
-    // Obtener el último objeto seleccionado
-    // const BoundingBox* lastSelected = mSelectedBoxes.last();
-    // QPointF lastPivot = lastSelected->getPivotAbsPos();
-
     if (relativeTo == AlignRelativeTo::scene) {
         if (align & Qt::AlignVCenter) {
             center.setX(currentPivot.x());
@@ -912,16 +908,16 @@ void BoundingBox::alignPivotItself(const Qt::Alignment align,
         } else if (align & Qt::AlignHCenter) {
             center.setX(currentPivot.x() - currentPivotAbsPos.x() + to.center().x());
             center.setY(currentPivot.y());
-        } else if (align & Qt::AlignLeft) { // OK
+        } else if (align & Qt::AlignLeft) {
             center.setX(currentPivot.x() - currentPivotAbsPos.x() + to.topLeft().x());
             center.setY(currentPivot.y());
-        } else if (align & Qt::AlignRight) { // OK
+        } else if (align & Qt::AlignRight) {
             center.setX(currentPivot.x() + (to.topRight().x() - currentPivotAbsPos.x()));
             center.setY(currentPivot.y());
-        } else if (align & Qt::AlignTop) { // OK
+        } else if (align & Qt::AlignTop) {
             center.setX(currentPivot.x());
             center.setY(currentPivot.y() - currentPivotAbsPos.y() + to.topLeft().y());
-        } else if (align & Qt::AlignBottom) { // OK
+        } else if (align & Qt::AlignBottom) {
             center.setX(currentPivot.x());
             center.setY(currentPivot.y() + (to.bottomRight().y() - currentPivotAbsPos.y()));
         }
@@ -956,8 +952,11 @@ void BoundingBox::alignPivotItself(const Qt::Alignment align,
         }
     }
 
+    startPosTransform();
+    // TODO: get undo/redo to save last previous state
     mTransformAnimator->setPivotFixedTransform(center);
     requestGlobalPivotUpdateIfSelected();
+    finishTransform();
 }
 
 void BoundingBox::moveByAbs(const QPointF &trans) {

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -865,6 +865,12 @@ void BoundingBox::alignPivot(const Qt::Alignment align, const QRectF& to) {
     alignGeometry(QRectF(pivot, pivot), align, to);
 }
 
+void BoundingBox::alignPivot2(const Qt::Alignment align, const QRectF& to) {
+    const auto center = getRelCenterPosition();
+    mTransformAnimator->setPivotFixedTransform(center);
+    requestGlobalPivotUpdateIfSelected();
+}
+
 void BoundingBox::moveByAbs(const QPointF &trans) {
     mTransformAnimator->moveByAbs(trans);
 }

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -40,6 +40,8 @@
 
 class Canvas;
 
+enum class AlignRelativeTo;
+
 class QrealAction;
 class MovablePoint;
 
@@ -298,7 +300,10 @@ public:
 
     void alignGeometry(const Qt::Alignment align, const QRectF& to);
     void alignPivot(const Qt::Alignment align, const QRectF& to);
-    void alignPivot2(const Qt::Alignment align, const QRectF& to);
+    void alignPivot2(const Qt::Alignment align,
+                     const QRectF& to,
+                     const AlignRelativeTo relativeTo,
+                     const QPointF lastPivotAbsPos);
 
     QMatrix getTotalTransform() const;
 
@@ -456,6 +461,9 @@ protected:
     void setRelBoundingRect(const QRectF& relRect);
 
     uint mStateId = 0;
+
+    int mWidth;
+    int mHeight;
 
     int mNReasonsNotToApplyUglyTransform = 0;
 protected:

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -298,6 +298,7 @@ public:
 
     void alignGeometry(const Qt::Alignment align, const QRectF& to);
     void alignPivot(const Qt::Alignment align, const QRectF& to);
+    void alignPivot2(const Qt::Alignment align, const QRectF& to);
 
     QMatrix getTotalTransform() const;
 

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -300,7 +300,7 @@ public:
 
     void alignGeometry(const Qt::Alignment align, const QRectF& to);
     void alignPivot(const Qt::Alignment align, const QRectF& to);
-    void alignPivot2(const Qt::Alignment align,
+    void alignPivotItself(const Qt::Alignment align,
                      const QRectF& to,
                      const AlignRelativeTo relativeTo,
                      const QPointF lastPivotAbsPos);

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -69,11 +69,11 @@ class eKeyEvent;
 enum class CtrlsMode : short;
 
 enum class AlignPivot {
-    geometry, pivot
+    geometry, pivot, pivot2
 };
 
 enum class AlignRelativeTo {
-    scene, lastSelected
+    scene, lastSelected, itself
 };
 
 class CORE_EXPORT Canvas : public CanvasBase

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -73,7 +73,7 @@ enum class AlignPivot {
 };
 
 enum class AlignRelativeTo {
-    scene, lastSelected, itself
+    scene, lastSelected, lastSelectedPivot, boundingBox
 };
 
 class CORE_EXPORT Canvas : public CanvasBase

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -69,7 +69,7 @@ class eKeyEvent;
 enum class CtrlsMode : short;
 
 enum class AlignPivot {
-    geometry, pivot, pivot2
+    geometry, pivot, pivotItself
 };
 
 enum class AlignRelativeTo {

--- a/src/core/canvasselectedboxesactions.cpp
+++ b/src/core/canvasselectedboxesactions.cpp
@@ -884,8 +884,8 @@ void Canvas::alignSelectedBoxes(const Qt::Alignment align,
         case AlignPivot::geometry:
             box->alignGeometry(align, geometry);
             break;
-        case AlignPivot::pivot2:
-            box->alignPivot2(align, geometry, relativeTo, mLastSelectedBox->getPivotAbsPos());
+        case AlignPivot::pivotItself:
+            box->alignPivotItself(align, geometry, relativeTo, mLastSelectedBox->getPivotAbsPos());
             break;
         }
     }

--- a/src/core/canvasselectedboxesactions.cpp
+++ b/src/core/canvasselectedboxesactions.cpp
@@ -864,13 +864,13 @@ void Canvas::alignSelectedBoxes(const Qt::Alignment align,
         skip = mLastSelectedBox;
         geometry = mLastSelectedBox->getAbsBoundingRect();
         break;
-    case AlignRelativeTo::itself:
-        // Usar el rectángulo del propio objeto como referencia
-        if (pivot == AlignPivot::pivot2) {
-            geometry = QRectF(0., 0., mWidth, mHeight);
-        } else {
-            geometry = QRectF(0., 0., mWidth, mHeight);
-        }
+    case AlignRelativeTo::lastSelectedPivot:
+        if(!mLastSelectedBox) return;
+        skip = mLastSelectedBox;
+        geometry = QRectF(mLastSelectedBox->getPivotAbsPos(),mLastSelectedBox->getPivotAbsPos());
+        break;
+    case AlignRelativeTo::boundingBox:
+        geometry = QRectF(0., 0., mWidth, mHeight); // TODO: not using it?
         break;
     }
 
@@ -885,7 +885,7 @@ void Canvas::alignSelectedBoxes(const Qt::Alignment align,
             box->alignGeometry(align, geometry);
             break;
         case AlignPivot::pivot2:
-            box->alignPivot2(align, geometry);
+            box->alignPivot2(align, geometry, relativeTo, mLastSelectedBox->getPivotAbsPos());
             break;
         }
     }

--- a/src/core/canvasselectedboxesactions.cpp
+++ b/src/core/canvasselectedboxesactions.cpp
@@ -864,6 +864,14 @@ void Canvas::alignSelectedBoxes(const Qt::Alignment align,
         skip = mLastSelectedBox;
         geometry = mLastSelectedBox->getAbsBoundingRect();
         break;
+    case AlignRelativeTo::itself:
+        // Usar el rectángulo del propio objeto como referencia
+        if (pivot == AlignPivot::pivot2) {
+            geometry = QRectF(0., 0., mWidth, mHeight);
+        } else {
+            geometry = QRectF(0., 0., mWidth, mHeight);
+        }
+        break;
     }
 
     pushUndoRedoName("align");
@@ -875,6 +883,9 @@ void Canvas::alignSelectedBoxes(const Qt::Alignment align,
             break;
         case AlignPivot::geometry:
             box->alignGeometry(align, geometry);
+            break;
+        case AlignPivot::pivot2:
+            box->alignPivot2(align, geometry);
             break;
         }
     }

--- a/src/ui/widgets/alignwidget.cpp
+++ b/src/ui/widgets/alignwidget.cpp
@@ -51,6 +51,7 @@ AlignWidget::AlignWidget(QWidget* const parent)
     mAlignPivot->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mAlignPivot->setFocusPolicy(Qt::NoFocus);
     mAlignPivot->addItem(tr("Align Geometry"));
+    mAlignPivot->addItem(tr("Align Geometry (Pivot)"));
     mAlignPivot->addItem(tr("Align Pivot"));
     combosLay->addWidget(mAlignPivot);
 
@@ -61,6 +62,7 @@ AlignWidget::AlignWidget(QWidget* const parent)
     mRelativeTo->setFocusPolicy(Qt::NoFocus);
     mRelativeTo->addItem(tr("Relative to Scene"));
     mRelativeTo->addItem(tr("Relative to Last Selected"));
+    mRelativeTo->addItem(tr("Itself"));
     combosLay->addWidget(mRelativeTo);
 
     const auto buttonsLay = new QHBoxLayout;

--- a/src/ui/widgets/alignwidget.cpp
+++ b/src/ui/widgets/alignwidget.cpp
@@ -42,35 +42,31 @@ AlignWidget::AlignWidget(QWidget* const parent)
     mainLayout->setContentsMargins(5, 5, 5, 5);
     setLayout(mainLayout);
 
-    // Crear un layout para las etiquetas encima de los combos
     const auto labelsLay = new QHBoxLayout;
-    mainLayout->insertLayout(0, labelsLay); // Insertar en la posición 0, encima de combosLay
+    mainLayout->insertLayout(0, labelsLay);
 
-    // Crear las etiquetas
     const auto labelAlignPivot = new QLabel(tr("Align:"), this);
-    labelAlignPivot->setAlignment(Qt::AlignLeft); // Alineación izquierda
-    labelsLay->addWidget(labelAlignPivot, 1); // Ocupa mitad del espacio
+    labelAlignPivot->setAlignment(Qt::AlignLeft);
+    labelsLay->addWidget(labelAlignPivot, 1);
 
     const auto labelRelativeTo = new QLabel(tr("Relative to:"), this);
-    labelRelativeTo->setAlignment(Qt::AlignLeft); // Alineación izquierda
-    labelsLay->addWidget(labelRelativeTo, 1); // Ocupa mitad del espacio
+    labelRelativeTo->setAlignment(Qt::AlignLeft);
+    labelsLay->addWidget(labelRelativeTo, 1);
 
-    labelsLay->addStretch(); // Añadir un estiramiento opcional para asegurar el alineamiento
+    labelsLay->addStretch();
 
     const auto combosLay = new QHBoxLayout;
     mainLayout->addLayout(combosLay);
 
-    //combosLay->addWidget(new QLabel(tr("Align")));
     mAlignPivot = new QComboBox(this);
     mAlignPivot->setMinimumWidth(20);
     mAlignPivot->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mAlignPivot->setFocusPolicy(Qt::NoFocus);
     mAlignPivot->addItem(tr("Geometry"));
-    mAlignPivot->addItem(tr("Geometry (Pivot)"));
+    mAlignPivot->addItem(tr("Geometry by Pivot"));
     mAlignPivot->addItem(tr("Pivot"));
     combosLay->addWidget(mAlignPivot);
 
-    //combosLay->addWidget(new QLabel(tr("Relative to")));
     mRelativeTo = new QComboBox(this);
     mRelativeTo->setMinimumWidth(20);
     mRelativeTo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -79,57 +75,25 @@ AlignWidget::AlignWidget(QWidget* const parent)
     mRelativeTo->addItem(tr("Last Selected"));
     combosLay->addWidget(mRelativeTo);
 
-    // Conectar la señal de cambio de índice
     connect(mAlignPivot, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
         static bool isItem2Removed = true;
 
-        if (index == 2) { // Si el índice seleccionado en mAlignPivot es 2
+        if (index == 2) {
             if (isItem2Removed) {
-                // Volvemos a insertar el índice 2 si no está presente
                 mRelativeTo->insertItem(2, tr("Last Selected Pivot"));
                 mRelativeTo->insertItem(3, tr("Bounding Box"));
                 isItem2Removed = false;
             }
-            mRelativeTo->setCurrentIndex(3); // Seleccionar el índice 2 en mRelativeTo
+            mRelativeTo->setCurrentIndex(3);
         } else {
             if (!isItem2Removed) {
-                // Eliminamos el índice 2 si está presente
                 mRelativeTo->removeItem(2);
                 mRelativeTo->removeItem(2);
                 isItem2Removed = true;
-                mRelativeTo->setCurrentIndex(0); // Seleccionar el índice 0 en mRelativeTo
+                mRelativeTo->setCurrentIndex(0);
             }
         }
     });
-
-
-    // // Crear mRelativeToPivot
-    // mRelativeToPivot = new QComboBox(this);
-    // mRelativeToPivot->setMinimumWidth(20);
-    // mRelativeToPivot->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    // mRelativeToPivot->setFocusPolicy(Qt::NoFocus);
-    // // Añadir opciones a mRelativeToPivot
-    // mRelativeToPivot->addItem(tr("Bounding Box")); // Index 0
-    // mRelativeToPivot->addItem(tr("Scene"));        // Index 1
-    // combosLay->addWidget(mRelativeToPivot);
-
-    // // Inicialmente, ocultamos mRelativeToPivot
-    // mRelativeToPivot->hide();
-
-    // // Conectar el cambio de mAlignPivot
-    // connect(mAlignPivot, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
-    //     if (index == 2) {
-    //         // Mostrar mRelativeToPivot y ocultar mRelativeTo
-    //         mRelativeTo->hide();
-    //         mRelativeToPivot->show();
-    //         mRelativeToPivot->setCurrentIndex(0); // Seleccionar siempre el índice 0
-    //     } else {
-    //         // Mostrar mRelativeTo y ocultar mRelativeToPivot
-    //         mRelativeToPivot->hide();
-    //         mRelativeTo->show();
-    //         mRelativeTo->setCurrentIndex(0); // Seleccionar siempre el índice 0
-    //     }
-    // });
 
     const auto buttonsLay = new QHBoxLayout;
     mainLayout->addLayout(buttonsLay);

--- a/src/ui/widgets/alignwidget.h
+++ b/src/ui/widgets/alignwidget.h
@@ -50,6 +50,7 @@ private:
 
     QComboBox *mAlignPivot;
     QComboBox *mRelativeTo;
+    QComboBox *mRelativeToPivot;
 };
 
 #endif // ALIGNWIDGET_H


### PR DESCRIPTION
Hi,

I've been working on this new feature the last two weeks. It's not finished yet but it is full feature ready so I thought it was the moment to show it.

Till now, the only graphical option to align the object pivot was by opening the contextual menu and selecting "Center pivot":

<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/881ca56d-18ce-406f-ba5c-669643234fb3">

I extended the geometry alignment widget to allow pivot alignment. In the way I restructured the dropdowns and renamed "Pivot" to "Geometry by Pivot" as it really aligns the geometry using the pivot as the center point.

Now "Pivot" option introduces real pivot alignment with options to align it to Scene, Last selected, Last selected pivot and Bounding Box (most common use):

![menus](https://github.com/user-attachments/assets/33e0192f-8be5-4eb1-b5ed-fb1ac7378226)

Please, have a look at the video showing them all:

https://github.com/user-attachments/assets/8b97c3a4-0e59-47d9-a500-9a5f1328dfad

I would say the feature state is the following:

- [x] align pivot relative to his bounding box
- [x] align pivot relative to scene
- [x] align pivot relative to last selected
- [x] align pivot relative to last selected pivot
- [ ] cleaning up not used functions and/or simplify it all
- [ ] make them undoable/redoable
- [ ] fix known issue: text object doesn't work properly when "align pivot relative to last selected pivot" (It kinda but not as expected)
- [ ] fix known issue: null object make Friction to crash when aligning pivot to any relative to option...

Help is appreciated as the remaining tasks could make me fall into a maze and loose a lot of time for probably simple fixes that I don't reach to find.... BTW, I'll continue trying, hehehe.

Cheers