### PR TITLE
Preview rearranged

### DIFF
--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -230,8 +230,6 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mRenderProgress->setFixedWidth(mCurrentFrameSpin->width());
     mRenderProgress->setFormat(tr("Cache %p%"));
 
-    mToolBar->addWidget(mFrameStartSpin);
-
     eSizesUI::widget.add(mToolBar, [this](const int size) {
         //mRenderProgress->setFixedHeight(eSizesUI::button);
         mToolBar->setIconSize(QSize(size, size));
@@ -244,13 +242,11 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
 
     mToolBar->addAction(mFrameRewindAct);
     mToolBar->addAction(mPrevKeyframeAct);
-    mToolBar->addAction(mNextKeyframeAct);
-    mToolBar->addAction(mFrameFastForwardAct);
-    mRenderProgressAct = mToolBar->addWidget(mRenderProgress);
-    mCurrentFrameSpinAct = mToolBar->addWidget(mCurrentFrameSpin);
     mToolBar->addAction(mPlayFromBeginningButton);
     mToolBar->addAction(mPlayButton);
     mToolBar->addAction(mStopButton);
+    mToolBar->addAction(mNextKeyframeAct);
+    mToolBar->addAction(mFrameFastForwardAct);
     mToolBar->addAction(mLoopButton);
 
     mMainWindow->cmdAddAction(mFrameRewindAct);
@@ -269,7 +265,13 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
                                  QSizePolicy::Minimum);
     mToolBar->addWidget(spacerWidget2);
 
+    mToolBar->addWidget(mFrameStartSpin);
+    mToolBar->addWidget(mCurrentFrameSpin);
+    mRenderProgressAct = mToolBar->addWidget(mRenderProgress);
+    mCurrentFrameSpinAct = mToolBar->addWidget(mCurrentFrameSpin);
     mToolBar->addWidget(mFrameEndSpin);
+
+    mRenderProgressAct->setVisible(false);
 
     mMainLayout->addWidget(mToolBar);
     mMainLayout->addSpacing(2);

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -82,7 +82,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mMainLayout->setSpacing(0);
     mMainLayout->setMargin(0);
 
-    mFrameRewindAct = new QAction(QIcon::fromTheme("rewind"),
+    // mFrameRewindAct = new QAction(QIcon::fromTheme("rewind"),
+    mFrameRewindAct = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_rewind.png"),
                                   tr("Rewind"),
                                   this);
     mFrameRewindAct->setShortcut(QKeySequence(AppSupport::getSettings("shortcuts",
@@ -97,7 +98,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
         mDocument.actionFinished();
     });
 
-    mFrameFastForwardAct = new QAction(QIcon::fromTheme("fastforward"),
+    // mFrameFastForwardAct = new QAction(QIcon::fromTheme("fastforward"),
+    mFrameFastForwardAct = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_fastforward.png"),
                                        tr("Fast Forward"),
                                        this);
     mFrameFastForwardAct->setShortcut(QKeySequence(AppSupport::getSettings("shortcuts",
@@ -112,7 +114,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
         mDocument.actionFinished();
     });
 
-    mPlayFromBeginningButton = new QAction(QIcon::fromTheme("preview"),
+    // mPlayFromBeginningButton = new QAction(QIcon::fromTheme("preview"),
+    mPlayFromBeginningButton = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_play-from-start.png"),
                                            tr("Play Preview From Start"),
                                            this);
     connect(mPlayFromBeginningButton, &QAction::triggered,
@@ -125,18 +128,21 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
         setPreviewFromStart(state);
     });
 
-    mPlayButton = new QAction(QIcon::fromTheme("play"),
+    // mPlayButton = new QAction(QIcon::fromTheme("play"),
+    mPlayButton = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_play.png"),
                               tr("Play Preview"),
                               this);
 
-    mStopButton = new QAction(QIcon::fromTheme("stop"),
+    // mStopButton = new QAction(QIcon::fromTheme("stop"),
+    mStopButton = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_stop.png"),
                               tr("Stop Preview"),
                               this);
 
     connect(mStopButton, &QAction::triggered,
             this, &TimelineDockWidget::interruptPreview);
 
-    mLoopButton = new QAction(QIcon::fromTheme("loop3"),
+    // mLoopButton = new QAction(QIcon::fromTheme("loop3"),
+    mLoopButton = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_loop3.png"),
                               tr("Loop Preview"),
                               this);
     mLoopButton->setCheckable(true);
@@ -197,7 +203,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mCurrentFrameSpin->setRange(-INT_MAX, INT_MAX);
     mCurrentFrameSpin->setReadOnly(true);
 
-    const auto mPrevKeyframeAct = new QAction(QIcon::fromTheme("prev_keyframe"),
+    // const auto mPrevKeyframeAct = new QAction(QIcon::fromTheme("prev_keyframe"),
+    const auto mPrevKeyframeAct = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_prev-keyframe.png"),
                                               QString(),
                                               this);
     mPrevKeyframeAct->setToolTip(tr("Previous Keyframe"));
@@ -209,7 +216,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
         }
     });
 
-    const auto mNextKeyframeAct = new QAction(QIcon::fromTheme("next_keyframe"),
+    // const auto mNextKeyframeAct = new QAction(QIcon::fromTheme("next_keyframe"),
+    const auto mNextKeyframeAct = new QAction(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_next-keyframe.png"),
                                               QString(),
                                               this);
     mNextKeyframeAct->setToolTip(tr("Next Keyframe"));
@@ -409,7 +417,8 @@ void TimelineDockWidget::previewFinished()
     showRenderStatus(false);
     mPlayFromBeginningButton->setDisabled(false);
     mStopButton->setDisabled(true);
-    mPlayButton->setIcon(QIcon::fromTheme("play"));
+    // mPlayButton->setIcon(QIcon::fromTheme("play"));
+    mPlayButton->setIcon(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_play.png"));
     mPlayButton->setText(tr("Play Preview"));
     disconnect(mPlayButton, nullptr, this, nullptr);
     connect(mPlayButton, &QAction::triggered,
@@ -424,7 +433,8 @@ void TimelineDockWidget::previewBeingPlayed()
     showRenderStatus(false);
     mPlayFromBeginningButton->setDisabled(true);
     mStopButton->setDisabled(false);
-    mPlayButton->setIcon(QIcon::fromTheme("pause"));
+    // mPlayButton->setIcon(QIcon::fromTheme("pause"));
+    mPlayButton->setIcon(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_pause.png"));
     mPlayButton->setText(tr("Pause Preview"));
     disconnect(mPlayButton, nullptr, this, nullptr);
     connect(mPlayButton, &QAction::triggered,
@@ -439,7 +449,8 @@ void TimelineDockWidget::previewBeingRendered()
     showRenderStatus(true);
     mPlayFromBeginningButton->setDisabled(true);
     mStopButton->setDisabled(false);
-    mPlayButton->setIcon(QIcon::fromTheme("play"));
+    // mPlayButton->setIcon(QIcon::fromTheme("play"));
+    mPlayButton->setIcon(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_play.png"));
     mPlayButton->setText(tr("Play Preview"));
     disconnect(mPlayButton, nullptr, this, nullptr);
     connect(mPlayButton, &QAction::triggered,
@@ -454,7 +465,8 @@ void TimelineDockWidget::previewPaused()
     showRenderStatus(false);
     mPlayFromBeginningButton->setDisabled(true);
     mStopButton->setDisabled(false);
-    mPlayButton->setIcon(QIcon::fromTheme("play"));
+    // mPlayButton->setIcon(QIcon::fromTheme("play"));
+    mPlayButton->setIcon(QIcon("/Users/pablo/GitHub/friction-icon-theme_pablo/hicolor/scalable/friction/preview_play.png"));
     mPlayButton->setText(tr("Resume Preview"));
     disconnect(mPlayButton, nullptr, this, nullptr);
     connect(mPlayButton, &QAction::triggered,

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -258,7 +258,18 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mMainWindow->cmdAddAction(mStopButton);
     mMainWindow->cmdAddAction(mLoopButton);
 
-    mRenderProgressAct->setVisible(false);
+    QToolButton* nextKeyframeButton = qobject_cast<QToolButton*>(mToolBar->widgetForAction(mNextKeyframeAct));
+    if (nextKeyframeButton) {
+        nextKeyframeButton->setObjectName("NextKeyframeButton");
+    }
+    QToolButton* prevKeyframeButton = qobject_cast<QToolButton*>(mToolBar->widgetForAction(mPrevKeyframeAct));
+    if (prevKeyframeButton) {
+        prevKeyframeButton->setObjectName("PrevKeyframeButton");
+    }
+    QToolButton* LoopButton = qobject_cast<QToolButton*>(mToolBar->widgetForAction(mLoopButton));
+    if (LoopButton) {
+        LoopButton->setObjectName("LoopButton");
+    }
 
     QWidget *spacerWidget2 = new QWidget(this);
     spacerWidget2->setSizePolicy(QSizePolicy::Expanding,

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -447,8 +447,8 @@ QToolBar#animationDockWidget QPushButton {
     border-color: %2;
 }
 
-QToolBar#animationDockWidget QToolButton::hover,
-QToolBar#animationDockWidget QPushButton::hover {
+QToolBar#animationDockWidget QToolButton:hover,
+QToolBar#animationDockWidget QPushButton:hover {
     border-color: %4;
 }
 

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -634,3 +634,15 @@ Friction--Ui--ToolBar::separator:vertical {
 Friction--Ui--ToolBar::separator:horizontal {
     width: 1px;
 }
+
+QToolButton#PrevKeyframeButton {
+    margin-right: %10;
+}
+
+QToolButton#NextKeyframeButton {
+    margin-left: %10;
+}
+
+QToolButton#LoopButton {
+    margin-left: %7;
+}

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -81,6 +81,10 @@ QSpinBox#SpinBoxNoButtons::down-button {
     width: 0;
     height: 0;
 }
+QSpinBox#SpinBoxNoButtons:hover {
+    background-color: %3;
+    border-color: %3;
+}
 
 QTabWidget#TabWidgetCenter::tab-bar {
     alignment: center;


### PR DESCRIPTION
This is a suggestion to change the arrangement of icon in the Preview toolbar. I feel like the UX could be improved here.

I started by checking how other common FOSS do (not including some if their UX was not inline with our set of icons, for instance Kdenlive):

<img width="964" alt="preview_blender" src="https://github.com/user-attachments/assets/44e53008-939f-4211-a31f-cc885d1f6e2f" />
<img width="617" alt="preview_krita" src="https://github.com/user-attachments/assets/8f91f289-c40c-4d3e-ac00-c84813a34ce5" />
<img width="922" alt="preview_synfig" src="https://github.com/user-attachments/assets/bf3d957d-29ad-4ac4-a07d-e308f43a0c1a" />
<img width="901" alt="preview_natron" src="https://github.com/user-attachments/assets/6f5d2f4b-4b3d-4d78-9431-1247f130bfa8" />

Then I created a new set of icons and started playing with rearrangement and therefore fine tuning the icons (iterate).

I don't want to go further in case you don't like it or want me to move in another direction. Here is the state I am now:

actual
<img width="1276" alt="preview_friction_actual" src="https://github.com/user-attachments/assets/7e298a64-1141-4cc0-b7be-f372c45347ed" />

proposed
<img width="1274" alt="preview_friction_proposed1" src="https://github.com/user-attachments/assets/1e31afa8-f85a-4688-9edf-2cdede791ad1" />

window screenshot
<img width="1348" alt="preview_friction_proposed1_full" src="https://github.com/user-attachments/assets/b90bf893-7f09-41fc-b320-77e65cfb94bd" />

video
https://github.com/user-attachments/assets/929abc5e-37fd-4b5a-a60c-14a77dbb9e97

In the way I fixed some little errors in the QSS and "deactivated" the actual keyframe spinbox hover state as you can't really use it to type anything...

Let me know what do you think about the subject

Cheers
