### PR TITLE
Add debian/ubuntu command to get dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,6 +2,9 @@
 
 Generic instructions for building Friction on supported systems.
 
+
+Friction uses Qt as its GUI toolkit. **Qt forces you to register a Qt Account to download Qt binaries** from Qt 5.15.10 onwards. If you don't want to lose your time, [register an account](https://login.qt.io/login) and [download the Qt installer](https://www.qt.io/download-dev). **If you care about your consumer rights, [compile Qt yourself](https://wiki.qt.io/Building_Qt_5_from_Git)**. Good luck!
+
 ## Requirements on Linux
 
 * pkg-config
@@ -33,6 +36,16 @@ Generic instructions for building Friction on supported systems.
 * libwebp
 * zlib
 * icu
+
+## Debian and Ubuntu
+
+In apt, libraries always begin with `lib`. When they are to be used to compile something else they also end with `-dev`. Except for `libjpeg-turbo8`, `zlib1g`, and `libqscintilla2-qt5-dev`, which use more complex names.
+
+```
+sudo apt install pkg-config ninja-build python3 cmake clang \
+libunwind-dev libexpat-dev libharfbuzz-dev libfreetype-dev libfontconfig-dev libpng-dev libwebp-dev libicu-dev \
+libjpeg-turbo8 zlib1g libqscintilla2-qt5-dev
+```
 
 ## Requirements on Windows
 


### PR DESCRIPTION
I spent a lot of time figuring out the dependencies. I added a command in the building guide for debian / ubuntu that lets you get them all.

I also added a warning on how to get Qt officially and a way to get it without registering a Qt Account.

In the future we need to work on the Windows documentation for beginners and improve the current one for linux/mac