### PR TITLE
Fix source typos

### DIFF
--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.cpp
@@ -286,7 +286,7 @@ void OutputSettingsDialog::addVideoCodec(const AVCodec* const codec,
     if(codec->type != AVMEDIA_TYPE_VIDEO) return;
     if(codec->capabilities & AV_CODEC_CAP_EXPERIMENTAL) return;
     if(codec->pix_fmts == nullptr) return;
-    if(avformat_query_codec(outputFormat, codec->id, COMPLIENCE) == 0) return;
+    if(avformat_query_codec(outputFormat, codec->id, COMPLIANCE) == 0) return;
     mVideoCodecsList << codec;
     const QString codecName(codec->long_name);
     mVideoCodecsComboBox->addItem(codecName);
@@ -303,7 +303,7 @@ void OutputSettingsDialog::addAudioCodec(const AVCodecID &codecId,
     if(currentCodec->type != AVMEDIA_TYPE_AUDIO) return;
     if(currentCodec->capabilities & AV_CODEC_CAP_EXPERIMENTAL) return;
     if(currentCodec->sample_fmts == nullptr) return;
-    if(avformat_query_codec(outputFormat, codecId, COMPLIENCE) == 0) return;
+    if(avformat_query_codec(outputFormat, codecId, COMPLIANCE) == 0) return;
     mAudioCodecsList << currentCodec;
     const QString codecName(currentCodec->long_name);
     mAudioCodecsComboBox->addItem(codecName);
@@ -568,12 +568,12 @@ void OutputSettingsDialog::updateAvailableOutputFormats() {
             //if(!currentFormat->codec_tag || !currentFormat->codec_tag[0]) continue;
 //            int supportedCodecs = 0;
 //            for(const AVCodecID &codecId : VIDEO_CODECS) {
-//                if(avformat_query_codec(currentFormat, codecId, COMPLIENCE) == 0) continue;
+//                if(avformat_query_codec(currentFormat, codecId, COMPLIANCE) == 0) continue;
 //                supportedCodecs++;
 //                break;
 //            }
 //            for(const AVCodecID &codecId : AUDIO_CODECS) {
-//                if(avformat_query_codec(currentFormat, codecId, COMPLIENCE) == 0) continue;
+//                if(avformat_query_codec(currentFormat, codecId, COMPLIANCE) == 0) continue;
 //                supportedCodecs++;
 //                break;
 //            }
@@ -593,12 +593,12 @@ void OutputSettingsDialog::updateAvailableOutputFormats() {
             //if(!currentFormat->codec_tag || !currentFormat->codec_tag[0]) continue;
 //            int supportedCodecs = 0;
 //            for(const AVCodecID &codecId : currentFormat->video_codec) {
-//                if(avformat_query_codec(currentFormat, codecId, COMPLIENCE) == 0) continue;
+//                if(avformat_query_codec(currentFormat, codecId, COMPLIANCE) == 0) continue;
 //                supportedCodecs++;
 //                break;
 //            }
 //            for(const AVCodecID &codecId : currentFormat->audio_codec) {
-//                if(avformat_query_codec(currentFormat, codecId, COMPLIENCE) == 0) continue;
+//                if(avformat_query_codec(currentFormat, codecId, COMPLIANCE) == 0) continue;
 //                supportedCodecs++;
 //                break;
 //            }
@@ -931,12 +931,12 @@ OutputSettingsDialog::FormatCodecs::FormatCodecs(
 //    bool defVidAdded = false;
 //    bool defAudAdded = false;
     for(const AVCodecID &vidCodec : vidCodecs) {
-        if(avformat_query_codec(mFormat, vidCodec, COMPLIENCE) == 0) continue;
+        if(avformat_query_codec(mFormat, vidCodec, COMPLIANCE) == 0) continue;
         mVidCodecs << vidCodec;
 //        if(vidCodec == mFormat->video_codec) defVidAdded = true;
     }
     for(const AVCodecID &audCodec : audioCodec) {
-        if(avformat_query_codec(mFormat, audCodec, COMPLIENCE) == 0) continue;
+        if(avformat_query_codec(mFormat, audCodec, COMPLIANCE) == 0) continue;
         mAudioCodecs << audCodec;
 //        if(audCodec == mFormat->audio_codec) defAudAdded = true;
     }
@@ -955,7 +955,7 @@ OutputSettingsDialog::FormatCodecs::FormatCodecs(
 //        const AVCodecTag *tags2 = mFormat->codec_tag[i];
 //        for(int j = 0; tags2[j].id != AV_CODEC_ID_NONE; j++) {
 //            AVCodecID codecId = tags2[j].id;
-//            if(avformat_query_codec(mFormat, codecId, COMPLIENCE) == 0) continue;
+//            if(avformat_query_codec(mFormat, codecId, COMPLIANCE) == 0) continue;
 //            AVCodec *codecT = avcodec_find_encoder(codecId);
 //            if(!codecT) continue;
 //            if(codecT->type == AVMEDIA_TYPE_VIDEO) {

--- a/src/app/GUI/RenderWidgets/outputsettingsdialog.h
+++ b/src/app/GUI/RenderWidgets/outputsettingsdialog.h
@@ -40,7 +40,7 @@
 #include "renderinstancesettings.h"
 #include "widgets/twocolumnlayout.h"
 
-#define COMPLIENCE FF_COMPLIANCE_NORMAL
+#define COMPLIANCE FF_COMPLIANCE_NORMAL
 
 class OutputSettingsDialog : public QDialog {
     Q_OBJECT

--- a/src/app/GUI/canvaswindowevents.cpp
+++ b/src/app/GUI/canvaswindowevents.cpp
@@ -63,7 +63,7 @@ void CanvasWindow::resizeEvent(QResizeEvent *e)
             const QPointF trans{dSize.width() / div, dSize.height() / div};
             translateView(trans);
         }
-        // e->oldSize() returns {-1, -1} after chaning parent
+        // e->oldSize() returns {-1, -1} after changing parent
         mOldSize = e->size();
     }
     GLWindow::resizeEvent(e);

--- a/src/core/Animators/outlinesettingsanimator.cpp
+++ b/src/core/Animators/outlinesettingsanimator.cpp
@@ -104,9 +104,9 @@ void OutlineSettingsAnimator::setPaintType(const PaintType paintType) {
     }
 }
 
-void OutlineSettingsAnimator::showHideChildrenBeforeChaningPaintType(
+void OutlineSettingsAnimator::showHideChildrenBeforeChangingPaintType(
         const PaintType newPaintType) {
-    PaintSettingsAnimator::showHideChildrenBeforeChaningPaintType(newPaintType);
+    PaintSettingsAnimator::showHideChildrenBeforeChangingPaintType(newPaintType);
     if(getPaintType() == BRUSHPAINT) ca_removeChild(mBrushSettings);
     if(newPaintType == BRUSHPAINT) ca_addChild(mBrushSettings);
 }

--- a/src/core/Animators/outlinesettingsanimator.h
+++ b/src/core/Animators/outlinesettingsanimator.h
@@ -37,7 +37,7 @@ protected:
     QDomElement prp_writePropertyXEV_impl(const XevExporter& exp) const;
     void prp_readPropertyXEV_impl(const QDomElement& ele, const XevImporter& imp);
 public:
-    void showHideChildrenBeforeChaningPaintType(const PaintType newPaintType);
+    void showHideChildrenBeforeChangingPaintType(const PaintType newPaintType);
 
     void prp_writeProperty_impl(eWriteStream& dst) const;
     void prp_readProperty_impl(eReadStream& src);

--- a/src/core/Animators/paintsettingsanimator.cpp
+++ b/src/core/Animators/paintsettingsanimator.cpp
@@ -400,7 +400,7 @@ void PaintSettingsAnimator::setCurrentColor(const QColor &color,
     mColor->setColor(color);
 }
 
-void PaintSettingsAnimator::showHideChildrenBeforeChaningPaintType(
+void PaintSettingsAnimator::showHideChildrenBeforeChangingPaintType(
         const PaintType newPaintType) {
     if(mPaintType == GRADIENTPAINT)
         setGradient(nullptr);
@@ -425,7 +425,7 @@ void PaintSettingsAnimator::setPaintType(const PaintType paintType) {
         prp_addUndoRedo(ur);
     }
 
-    showHideChildrenBeforeChaningPaintType(paintType);
+    showHideChildrenBeforeChangingPaintType(paintType);
 
     mPaintType = paintType;
     updateGradientPoint();
@@ -456,13 +456,13 @@ UpdatePaintSettings::UpdatePaintSettings() {}
 UpdatePaintSettings::~UpdatePaintSettings() {}
 
 void UpdatePaintSettings::applyPainterSettingsSk(
-        SkPaint& paint, const float opactiy) {
+        SkPaint& paint, const float opacity) {
     if(fPaintType == GRADIENTPAINT) {
         paint.setShader(fGradient);
-        paint.setAlphaf(opactiy);
+        paint.setAlphaf(opacity);
     } else if(fPaintType == FLATPAINT) {
         paint.setColor(toSkColor(fPaintColor));
-        paint.setAlphaf(paint.getAlphaf()*opactiy);
+        paint.setAlphaf(paint.getAlphaf()*opacity);
     } else {
         paint.setColor(SkColorSetARGB(0, 0, 0, 0));
     }

--- a/src/core/Animators/paintsettingsanimator.h
+++ b/src/core/Animators/paintsettingsanimator.h
@@ -51,7 +51,7 @@ protected:
     PaintSettingsAnimator(const QString &name,
                           BoundingBox * const parent);
 
-    virtual void showHideChildrenBeforeChaningPaintType(
+    virtual void showHideChildrenBeforeChangingPaintType(
             const PaintType newPaintType);
 
     QDomElement prp_writePropertyXEV_impl(const XevExporter& exp) const;
@@ -130,7 +130,7 @@ struct CORE_EXPORT UpdatePaintSettings {
 
     virtual ~UpdatePaintSettings();
 
-    void applyPainterSettingsSk(SkPaint& paint, const float opactiy = 1.f);
+    void applyPainterSettingsSk(SkPaint& paint, const float opacity = 1.f);
 
     void updateGradient(const QGradientStops &stops,
                         const QPointF &start,

--- a/src/core/Animators/qrealanimator.cpp
+++ b/src/core/Animators/qrealanimator.cpp
@@ -55,15 +55,15 @@ void QrealAnimator::prp_setupTreeViewMenu(PropertyMenu * const menu) {
 
     const PropertyMenu::PlainSelectedOp<QrealAnimator> sOp =
     [](QrealAnimator * aTarget) {
-        const auto& intrface = DialogsInterface::instance();
-        intrface.showExpressionDialog(aTarget);
+        const auto& iface = DialogsInterface::instance();
+        iface.showExpressionDialog(aTarget);
     };
     menu->addPlainAction(QIcon::fromTheme("preferences"), tr("Set Expression"), sOp);
 
     const PropertyMenu::PlainSelectedOp<QrealAnimator> aOp =
     [](QrealAnimator * aTarget) {
-        const auto& intrface = DialogsInterface::instance();
-        intrface.showApplyExpressionDialog(aTarget);
+        const auto& iface = DialogsInterface::instance();
+        iface.showApplyExpressionDialog(aTarget);
     };
     menu->addPlainAction(QIcon::fromTheme("dialog-ok"), tr("Apply Expression"), aOp)->setEnabled(hasExpression());
 

--- a/src/core/FileCacheHandlers/filehandlerobjref.cpp
+++ b/src/core/FileCacheHandlers/filehandlerobjref.cpp
@@ -1,9 +1,9 @@
 #include "filehandlerobjref.h"
 
-void FileHandlerObjRefBase::increment(FileCacheHandler * const hadler) const {
-    hadler->mReferenceCount++;
+void FileHandlerObjRefBase::increment(FileCacheHandler * const handler) const {
+    handler->mReferenceCount++;
 }
 
-void FileHandlerObjRefBase::decrement(FileCacheHandler * const hadler) const {
-    hadler->mReferenceCount--;
+void FileHandlerObjRefBase::decrement(FileCacheHandler * const handler) const {
+    handler->mReferenceCount--;
 }

--- a/src/core/FileCacheHandlers/filehandlerobjref.h
+++ b/src/core/FileCacheHandlers/filehandlerobjref.h
@@ -30,8 +30,8 @@
 class CORE_EXPORT FileHandlerObjRefBase : public QObject {
 protected:
     FileHandlerObjRefBase() {}
-    void increment(FileCacheHandler* const hadler) const;
-    void decrement(FileCacheHandler* const hadler) const;
+    void increment(FileCacheHandler* const handler) const;
+    void decrement(FileCacheHandler* const handler) const;
 };
 
 template <class T>

--- a/src/core/Paint/simplebrushwrapper.h
+++ b/src/core/Paint/simplebrushwrapper.h
@@ -66,7 +66,7 @@ public:
                   const float value,
                   const float opacity) const {
         setColor(hue, saturation, value);
-        setOpactiy(opacity);
+        setOpacity(opacity);
     }
 
     void setColor(const QColor& color) const {
@@ -74,7 +74,7 @@ public:
                  float(color.valueF()), float(color.alphaF()));
     }
 
-    void setOpactiy(const float opacity) const {
+    void setOpacity(const float opacity) const {
         Q_UNUSED(opacity)
         //setBaseValue(MYPAINT_BRUSH_SETTING_OPAQUE, clamp(opacity, 0, 1));
     }
@@ -82,7 +82,7 @@ public:
     void incOpacity(const qreal inc) {
         Q_UNUSED(inc)
         //const float opacity = getBaseValue(MYPAINT_BRUSH_SETTING_OPAQUE);
-        //setOpactiy(opacity + float(inc));
+        //setOpacity(opacity + float(inc));
     }
 
     void decOpacity(const qreal dec) {


### PR DESCRIPTION
Found via `codespell -q 3 -L indexin,kno,rightt,thist,uptodate`  
Closes #360

This PR is untested. Also there was hesitance for me around fixing the following typos (so I didn't).

https://github.com/search?q=repo%3Afriction2d%2Ffriction%20chaning&type=code
Is the word here, 'changing' ?

https://github.com/search?q=repo%3Afriction2d%2Ffriction%20preffered&type=code  
This should probably be 'preferred' but there are many instances of it and probably should be left alone.
