### PR TITLE
Make current keyframe QSpinBox non hoverable and non editable

### DIFF
--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -196,6 +196,7 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mCurrentFrameSpin->setToolTip(tr("Current frame"));
     mCurrentFrameSpin->setRange(-INT_MAX, INT_MAX);
     mCurrentFrameSpin->setReadOnly(true);
+    mCurrentFrameSpin->setEnabled(false);
 
     const auto mPrevKeyframeAct = new QAction(QIcon::fromTheme("prev_keyframe"),
                                               QString(),

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -447,8 +447,8 @@ QToolBar#animationDockWidget QPushButton {
     border-color: %2;
 }
 
-QToolBar#animationDockWidget QToolButton::hover,
-QToolBar#animationDockWidget QPushButton::hover {
+QToolBar#animationDockWidget QToolButton:hover,
+QToolBar#animationDockWidget QPushButton:hover {
     border-color: %4;
 }
 

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -35,6 +35,7 @@ Colors and icon size from 'src/core/themesupport.cpp'.
 %11 = icon pixel ratio
 %12 = half icon pixel ratio
 %13 = getThemeColorTextDisabled
+#%14 = getThemeColorText
 
 */
 
@@ -85,6 +86,10 @@ QSpinBox#SpinBoxNoButtons::down-button {
 QSpinBox#SpinBoxNoButtons:hover {
     background-color: %3;
     border-color: %3;
+}
+
+QSpinBox#SpinBoxNoButtons:disabled {
+    color: %14;
 }
 
 QTabWidget#TabWidgetCenter::tab-bar {

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -480,7 +480,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled,
-AlignWidget QPushButton::disabled {
+AlignWidget QPushButton:disabled {
     background: transparent;
 }
 
@@ -595,7 +595,7 @@ QProgressBar::chunk {
     width: 5px;
 }
 
-QCheckBox::disabled {
+QCheckBox:disabled {
     color: %13;
 }
 

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -82,6 +82,11 @@ QSpinBox#SpinBoxNoButtons::down-button {
     height: 0;
 }
 
+QSpinBox#SpinBoxNoButtons:hover {
+    background-color: %3;
+    border-color: %3;
+}
+
 QTabWidget#TabWidgetCenter::tab-bar {
     alignment: center;
 }

--- a/src/core/themesupport.cpp
+++ b/src/core/themesupport.cpp
@@ -167,6 +167,11 @@ const QColor ThemeSupport::getThemeColorTextDisabled(int alpha)
     return getQColor(112, 112, 113, alpha);
 }
 
+const QColor ThemeSupport::getThemeColorText(int alpha)
+{
+    return getQColor(255, 255, 255, alpha);
+}
+
 const QPalette ThemeSupport::getDefaultPalette(const QColor &highlight)
 {
     QPalette palette;
@@ -237,7 +242,8 @@ const QString ThemeSupport::getThemeStyle(int iconSize)
                    QString::number(getIconSize(iconSize / 2).width()),
                    QString::number(getIconSize(qRound(iconPixelRatio)).width()),
                    QString::number(getIconSize(qRound(iconPixelRatio / 2)).width()),
-                   getThemeColorTextDisabled().name());
+                   getThemeColorTextDisabled().name(),
+                   getThemeColorText().name());
 }
 
 void ThemeSupport::setupTheme(const int iconSize)

--- a/src/core/themesupport.h
+++ b/src/core/themesupport.h
@@ -63,6 +63,7 @@ public:
     static const QColor getThemeColorGreenDark(int alpha = 255);
     static const QColor getThemeColorOrange(int alpha = 255);
     static const QColor getThemeColorTextDisabled(int alpha = 255);
+    static const QColor getThemeColorText(int alpha = 255);
     static const QPalette getDefaultPalette(const QColor &highlight = QColor());
     static const QPalette getDarkPalette(int alpha = 255);
     static const QPalette getDarkerPalette(int alpha = 255);


### PR DESCRIPTION
As it is not editable, it just shows information about the current frame.

In the way I fixed some "hover" and "disable" pseudo-states definitions that were marked as pseudo-elements, that is, they were using `::` but they should use `:`.