### PR TITLE
Fix shader 'texture' usage

### DIFF
--- a/src/core/RasterEffects/brightnesscontrasteffect.frag
+++ b/src/core/RasterEffects/brightnesscontrasteffect.frag
@@ -28,11 +28,11 @@ layout(location = 0) out vec4 fragColor;
 
 in vec2 texCoord;
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform float brightness;
 uniform float contrast;
 
 void main(void) {
-    vec4 color = texture2D(texture, texCoord);
+    vec4 color = texture(tex, texCoord);
     fragColor = vec4((color.rgb - 0.5*color.a) * (contrast + 1) + color.a*(0.5 + brightness), color.a);
 }

--- a/src/core/RasterEffects/colorizeeffect.frag
+++ b/src/core/RasterEffects/colorizeeffect.frag
@@ -28,7 +28,7 @@ layout(location = 0) out vec4 fragColor;
 
 in vec2 texCoord;
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 uniform float influence;
 uniform float hue;
@@ -67,7 +67,7 @@ vec3 RGBtoHSL(in vec3 RGB) {
 }
 
 void main(void) {
-    vec4 texColor = texture2D(texture, texCoord);
+    vec4 texColor = texture(tex, texCoord);
     if(texColor.a < 0.00001f) {
         fragColor = texColor;
     } else {

--- a/src/core/RasterEffects/motionblureffect.cpp
+++ b/src/core/RasterEffects/motionblureffect.cpp
@@ -223,10 +223,10 @@ void MotionBlurCaller::sInitialize(QGL33 * const gl) {
 
     gl->glUseProgram(sProgramId);
 
-    const GLint texture1 = gl->glGetUniformLocation(sProgramId, "texture1");
+    const GLint texture1 = gl->glGetUniformLocation(sProgramId, "tex1");
     gl->glUniform1i(texture1, 0);
 
-    const GLint texture2 = gl->glGetUniformLocation(sProgramId, "texture2");
+    const GLint texture2 = gl->glGetUniformLocation(sProgramId, "tex2");
     gl->glUniform1i(texture2, 1);
 
     sOpacity2Loc = gl->glGetUniformLocation(sProgramId, "opacity2");

--- a/src/core/RasterEffects/noisefadeeffect.frag
+++ b/src/core/RasterEffects/noisefadeeffect.frag
@@ -32,7 +32,7 @@ layout(location = 0) out vec4 fragColor;
 
 in vec2 texCoord;
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 uniform float seed;
 uniform float size;
@@ -69,5 +69,5 @@ void main(void) {
 
     float b = 0.25*(0.75 - 0.749*sharpness);
     float c = smoothstep(t + b, t - b, noise(texCoord * .4));
-    fragColor = mix(texture2D(texture, texCoord), vec4(0), c);
+    fragColor = mix(texture(tex, texCoord), vec4(0), c);
 }

--- a/src/core/RasterEffects/openglrastereffectcaller.cpp
+++ b/src/core/RasterEffects/openglrastereffectcaller.cpp
@@ -70,7 +70,7 @@ void OpenGLRasterEffectCaller::iniProgram(QGL33* const gl) {
 
     gl->glUseProgram(mProgramId);
 
-    const auto texLocation = gl->glGetUniformLocation(mProgramId, "texture");
+    const auto texLocation = gl->glGetUniformLocation(mProgramId, "tex");
     gl->glUniform1i(texLocation, 0);
 
     iniVars(gl);

--- a/src/core/RasterEffects/wipeeffect.frag
+++ b/src/core/RasterEffects/wipeeffect.frag
@@ -28,7 +28,7 @@ layout(location = 0) out vec4 fragColor;
 
 in vec2 texCoord;
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 uniform float sharpness;
 uniform float direction;
@@ -70,5 +70,5 @@ void main(void) {
     } else {
         alpha = 1 - 0.5*(cos(PI*(f - x0)/(1 - sharpness)) + 1);
     }
-    fragColor = texture2D(texture, texCoord) * alpha;
+    fragColor = texture(tex, texCoord) * alpha;
 }

--- a/src/core/ShaderEffects/shadereffectprogram.cpp
+++ b/src/core/ShaderEffects/shadereffectprogram.cpp
@@ -64,7 +64,7 @@ void ShaderEffectProgram::reloadFragmentShader(
         valueLocs.append(loc);
     }
 
-    GLint texLocation = gl->glGetUniformLocation(newProgram, "texture");
+    GLint texLocation = gl->glGetUniformLocation(newProgram, "tex");
     if(texLocation < 0) {
         gl->glDeleteProgram(newProgram);
         RuntimeThrow("Invalid location received for 'texture'.");

--- a/src/core/appsupport.cpp
+++ b/src/core/appsupport.cpp
@@ -509,20 +509,6 @@ const QString AppSupport::getRasterEffectHardwareSupportString(const QString &ef
     return result;
 }
 
-const QByteArray AppSupport::filterShader(QByteArray data)
-{
-#if defined(Q_OS_WIN)
-    if (HardwareInfo::sGpuVendor() == GpuVendor::intel) {
-        return data.replace("texture2D", "texture");
-    }
-    return data;
-#elif defined(Q_OS_MAC)
-    return data.replace("texture2D", "texture");
-#else
-    return data;
-#endif
-}
-
 const QStringList AppSupport::getFpsPresets()
 {
     QStringList presets = getSettings("presets",

--- a/src/core/appsupport.h
+++ b/src/core/appsupport.h
@@ -102,7 +102,6 @@ public:
                                                           HardwareSupport fallback);
     static const QString getRasterEffectHardwareSupportString(const QString &effect,
                                                               HardwareSupport fallback);
-    static const QByteArray filterShader(QByteArray data);
     static const QStringList getFpsPresets();
     static void saveFpsPresets(const QStringList &presets);
     static void saveFpsPreset(const double value);

--- a/src/core/glhelpers.cpp
+++ b/src/core/glhelpers.cpp
@@ -141,14 +141,14 @@ void gIniProgram(QGL33 * const gl, GLuint& program,
         QFile vShaderFile(vShaderPath);
         if(!vShaderFile.open(QIODevice::ReadOnly))
             RuntimeThrow("Could not open " + vShaderPath);
-        const QByteArray vData = AppSupport::filterShader(vShaderFile.readAll());
+        const QByteArray vData = vShaderFile.readAll();
         vertexCode = vData.toStdString();
         vShaderFile.close();
 
         QFile fShaderFile(fShaderPath);
         if(!fShaderFile.open(QIODevice::ReadOnly))
             RuntimeThrow("Could not open " + fShaderPath);
-        const QByteArray fData = AppSupport::filterShader(fShaderFile.readAll());
+        const QByteArray fData = fShaderFile.readAll();
         fragmentCode = fData.toStdString();
         fShaderFile.close();
     } catch(...) {

--- a/src/core/shaders/maxalpha.frag
+++ b/src/core/shaders/maxalpha.frag
@@ -28,20 +28,20 @@ layout(location = 0) out vec4 fragColor;
 
 in vec2 texCoord;
 
-uniform sampler2D texture1;
-uniform sampler2D texture2;
+uniform sampler2D tex1;
+uniform sampler2D tex2;
 
 uniform vec4 rect2;
 uniform float opacity2;
 
 void main(void) {
-    vec4 color1 = texture2D(texture1, texCoord);
+    vec4 color1 = texture(tex1, texCoord);
     bool inRect2 = texCoord.x > rect2.x &&
                    texCoord.y > rect2.y &&
                    texCoord.x < rect2.z &&
                    texCoord.y < rect2.w;
     if(inRect2) {
-        vec4 color2 = opacity2*texture2D(texture2, (texCoord - rect2.xy)/(rect2.zw - rect2.xy));
+        vec4 color2 = opacity2*texture(tex2, (texCoord - rect2.xy)/(rect2.zw - rect2.xy));
         if(color2.a > color1.a) {
             float m2 = 1 - color1.a/color2.a;
             fragColor = color1 + color2*m2;


### PR DESCRIPTION
Fix deprecated `texture2D` and remove workarounds.

External shaders has also been updated: https://github.com/friction2d/friction-shader-plugins/pull/2 (will be merged after this PR).

Ref: #272