### PR TITLE
Change Expressions "Editor" and "Easing" tabs order

### DIFF
--- a/src/app/GUI/Expressions/expressiondialog.cpp
+++ b/src/app/GUI/Expressions/expressiondialog.cpp
@@ -453,15 +453,15 @@ ExpressionDialog::ExpressionDialog(QrealAnimator* const target,
 
     easingPresetLayout->addWidget(easingPresetButtonWidget);
 
+    QWidget *editorWidget = new QWidget(this);
+    mTabEditor = mTab->addTab(editorWidget, tr("Editor"));
+    const auto mainLayout = new QVBoxLayout(editorWidget);
+
     if (populateEasingPresets()) {
         mTabEasingPreset = mTab->addTab(easingPresetWidget, tr("Easing"));
     } else {
         easingPresetWidget->setVisible(false);
     }
-
-    QWidget *editorWidget = new QWidget(this);
-    mTabEditor = mTab->addTab(editorWidget, tr("Editor"));
-    const auto mainLayout = new QVBoxLayout(editorWidget);
 
     const auto tabLayout = new QHBoxLayout;
     tabLayout->setSpacing(0);


### PR DESCRIPTION
A simple UX change but it is much more common that you want to edit an expression than adding a easing to your timeline, do you agree?

<img width="468" alt="tabs" src="https://github.com/user-attachments/assets/174f5add-0a14-4c51-9db4-b1b153a481d3" />
