### PR TITLE
UI/UX: assets moved to main toolbar

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -72,6 +72,7 @@
 #include "appsupport.h"
 #include "themesupport.h"
 
+#include "widgets/toolbutton.h"
 #include "widgets/assetswidget.h"
 #include "dialogs/adjustscenedialog.h"
 #include "dialogs/commandpalette.h"
@@ -257,7 +258,7 @@ MainWindow::MainWindow(Document& document,
     connect(mObjectSettingsScrollArea, &ScrollArea::widthChanged,
             mObjectSettingsWidget, &BoxScrollWidget::setWidth);
 
-    const auto assets = new AssetsWidget(this);
+    //const auto assets = new AssetsWidget(this);
 
     setupToolBox();
     setupToolBar();
@@ -321,9 +322,9 @@ MainWindow::MainWindow(Document& document,
     mTabPropertiesIndex = mTabProperties->addTab(propertiesWidget,
                                                  QIcon::fromTheme("drawPathAutoChecked"),
                                                  tr("Properties"));
-    mTabAssetsIndex = mTabProperties->addTab(assets,
+    /*mTabAssetsIndex = mTabProperties->addTab(assets,
                                              QIcon::fromTheme("asset_manager"),
-                                             tr("Assets"));
+                                             tr("Assets"));*/
     mTabQueueIndex = mTabProperties->addTab(mRenderWidget,
                                             QIcon::fromTheme("render_animation"),
                                             tr("Queue"));
@@ -1100,6 +1101,43 @@ void MainWindow::setupMenuBar()
     mToolbar->addAction(mImportAct);
     mToolbar->addAction(mLinkedAct);
 
+    // assets action
+    const auto assetsButton = new Ui::ToolButton(this, false);
+    assetsButton->setObjectName("ToolButton");
+    assetsButton->setIcon(QIcon::fromTheme("asset_manager"));
+    assetsButton->setText(tr("Assets"));
+    assetsButton->setFocusPolicy(Qt::NoFocus);
+    assetsButton->setPopupMode(QToolButton::ToolButtonPopupMode::InstantPopup);
+    assetsButton->setToolButtonStyle(mToolbar->toolButtonStyle());
+    assetsButton->setAcceptDrops(true);
+
+    const auto assetsWid = new AssetsWidget(this);
+
+    const auto pop = new QFrame(this);
+    pop->setObjectName("PopWidget");
+    pop->setMinimumSize({320, 256});
+    pop->setContentsMargins(0, 0, 0, 0);
+
+    const auto popLay = new QVBoxLayout(pop);
+    popLay->setMargin(0);
+    popLay->addWidget(assetsWid);
+
+    const auto assetsWA = new QWidgetAction(this);
+    assetsWA->setDefaultWidget(pop);
+
+    assetsButton->addAction(assetsWA);
+
+    connect(assetsButton, &Ui::ToolButton::droppedUrls,
+            assetsWid, &AssetsWidget::addAssets);
+
+    const auto assetsAct = mToolbar->addWidget(assetsButton);
+    assetsAct->setObjectName("AssetsAct");
+    assetsAct->setText(tr("Assets"));
+
+    connect(mToolbar, &QToolBar::toolButtonStyleChanged,
+            assetsButton, &QToolButton::setToolButtonStyle);
+
+    // render actions
     mRenderVideoAct = mToolbar->addAction(QIcon::fromTheme("render_animation"),
                                           tr("Render"),
                                           this, &MainWindow::openRendererWindow);


### PR DESCRIPTION
I hate wasting space and the assets tab is IMHO annoying, why not just a button in the toolbar?

Click to get a popup with assets, you can drag-and-drop on the button.

This is a suggestion, please try and give feedback:

* Win: https://github.com/friction2d/friction/actions/runs/12809782871
* Lin: https://github.com/friction2d/friction/actions/runs/12809782882
* Mac: https://github.com/friction2d/friction/actions/runs/12809782869

![Screenshot from 2025-01-16 14-12-10](https://github.com/user-attachments/assets/b47b8283-3b96-4d95-ba78-f59d4e330873)
![Screenshot from 2025-01-16 14-13-17](https://github.com/user-attachments/assets/fd6cc361-eb6f-471f-8ce6-607048e920d8)

https://github.com/user-attachments/assets/788bd223-d5a5-4d6c-9dac-f3646460bc33

