### PR TITLE
Support expressions plugins/bundle

### DIFF
--- a/src/app/GUI/Expressions/expressiondialog.cpp
+++ b/src/app/GUI/Expressions/expressiondialog.cpp
@@ -280,6 +280,10 @@ void addBasicDefs(QsciAPIs* const target) {
     target->add("Math.tan(x)");
     target->add("Math.tanh(x)");
     target->add("Math.trunc(x)");
+
+    // load expressions bundle
+    const auto bundle = eSettings::instance().expressionsBundle;
+    for (const auto &fun : bundle) { target->add(fun.first); }
 }
 
 ExpressionDialog::ExpressionDialog(QrealAnimator* const target,

--- a/src/core/Expressions/expression.cpp
+++ b/src/core/Expressions/expression.cpp
@@ -26,6 +26,7 @@
 #include "expression.h"
 
 #include "exceptions.h"
+#include "Private/esettings.h"
 
 Expression::ResultTester Expression::sQrealAnimatorTester =
         [](const QJSValue& val) {
@@ -60,8 +61,14 @@ void throwIfError(const QJSValue& value, const QString& name) {
 }
 
 void Expression::sAddDefinitionsTo(const QString& definitionsStr,
-                                   QJSEngine& e) {
-    const auto defRet = e.evaluate(definitionsStr);
+                                   QJSEngine& e)
+{
+    QString defs;
+    const auto bundle = eSettings::instance().expressionsBundle;
+    for (const auto &fun : bundle) { defs.append(fun.second); }
+    defs.append(definitionsStr);
+
+    const auto defRet = e.evaluate(defs);
     throwIfError(defRet, "Definitions");
 }
 

--- a/src/core/Expressions/functions/clamp.conf
+++ b/src/core/Expressions/functions/clamp.conf
@@ -1,0 +1,1 @@
+target="clamp(x, lower, upper)"

--- a/src/core/Expressions/functions/clamp.js
+++ b/src/core/Expressions/functions/clamp.js
@@ -1,0 +1,3 @@
+function clamp(number, lower, upper) {
+    return Math.max(lower, Math.min(number, upper));
+}

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -159,6 +159,9 @@ public:
     QList<QAction*> fCommandPalette;
     QList<QString> fCommandHistory;
 
+    // Expressions bundle
+    QList<QPair<QString,QString>> expressionsBundle = AppSupport::getExpressionsBundle();
+
 signals:
     void settingsChanged();
 

--- a/src/core/appsupport.cpp
+++ b/src/core/appsupport.cpp
@@ -324,7 +324,7 @@ const QString AppSupport::getAppExPresetsPath()
     QString path1 = getAppPath();
     QString path2 = path1;
     path1.append(QString::fromUtf8("/plugins/expressions"));
-    path2.append(QString::fromUtf8("/../share/plugins/presets/expressions"));
+    path2.append(QString::fromUtf8("/../share/friction/plugins/expressions"));
     if (QFile::exists(path1)) { return path1; }
     if (QFile::exists(path2)) { return path2; }
     return QString();

--- a/src/core/appsupport.cpp
+++ b/src/core/appsupport.cpp
@@ -1120,3 +1120,28 @@ const QString AppSupport::filterId(const QString &input)
 {
     return QString(input).simplified().replace(" ", "");
 }
+
+const QList<QPair<QString, QString> > AppSupport::getExpressionsBundle()
+{
+    QStringList functions;
+    functions << "clamp";
+
+    QList<QPair<QString, QString> > result;
+    for (const auto &fun : functions) {
+        const QString funConf = QString(":/expressions/%1.conf").arg(fun);
+        const QString funJs = QString(":/expressions/%1.js").arg(fun);
+        if (!QFile::exists(funConf) || !QFile::exists(funJs)) { continue; }
+        QPair<QString,QString> expr;
+        QSettings conf(funConf, QSettings::IniFormat);
+        expr.first = conf.value("target").toString();
+        QFile funFile(funJs);
+        if (funFile.open(QIODevice::Text | QIODevice::ReadOnly)) {
+            expr.second = funFile.readAll();
+            funFile.close();
+        }
+        if (expr.first.isEmpty() || expr.second.isEmpty()) { continue; }
+        qDebug() << "adding expression function" << expr.first;
+        result << expr;
+    }
+    return result;
+}

--- a/src/core/appsupport.h
+++ b/src/core/appsupport.h
@@ -140,6 +140,7 @@ public:
     static const QList<QPair<QString,QString>> getEasingPresets();
     static void handlePortableFirstRun();
     static const QString filterId(const QString &input);
+    static const QList<QPair<QString,QString>> getExpressionsBundle();
 };
 
 #endif // APPSUPPORT_H

--- a/src/core/appsupport.h
+++ b/src/core/appsupport.h
@@ -141,6 +141,8 @@ public:
     static void handlePortableFirstRun();
     static const QString filterId(const QString &input);
     static const QList<QPair<QString,QString>> getExpressionsBundle();
+    static const QList<QPair<QString,QString>> findExpressions(const QStringList &paths);
+    static const QStringList scanForExpressions(const QString &path);
 };
 
 #endif // APPSUPPORT_H

--- a/src/core/coreresources.qrc
+++ b/src/core/coreresources.qrc
@@ -21,4 +21,8 @@
         <file alias="red.frag">colorshaders/red.frag</file>
         <file alias="value.frag">colorshaders/value.frag</file>
     </qresource>
+    <qresource prefix="/expressions">
+        <file alias="clamp.conf">Expressions/functions/clamp.conf</file>
+        <file alias="clamp.js">Expressions/functions/clamp.js</file>
+    </qresource>
 </RCC>


### PR DESCRIPTION
Support extending the default selection of JS functions in Qt, currently only supports functions bundled with Friction ('clamp'), but can easily be modified to scan a user defined directory.

Added 'clamp' as an example:

![Screenshot 2025-01-26 at 22 14 00](https://github.com/user-attachments/assets/a2bbd905-3cb3-46a0-94f2-4daae9b80a49)

@pgilfernandez
