### PR TITLE
Playback based on preview steps

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -970,6 +970,21 @@ void MainWindow::setupMenuBar()
     connect(mClipViewToCanvas, &QAction::triggered,
             &mActions, &Actions::setClipToCanvas);
 
+    const auto previewCacheAct = mViewMenu->addAction(tr("Preview Cache"));
+    previewCacheAct->setCheckable(true);
+    previewCacheAct->setChecked(eSettings::instance().fPreviewCache);
+    connect(previewCacheAct, &QAction::triggered,
+            this, [this, previewCacheAct]() {
+        const bool checked = previewCacheAct->isChecked();
+        eSettings::sInstance->fPreviewCache = checked;
+        eSettings::sInstance->saveKeyToFile("PreviewCache");
+        statusBar()->showMessage(tr("%1 Preview Cache").arg(checked ?
+                                                                tr("Enabled") :
+                                                                tr("Disabled")),
+                                 5000);
+    });
+    cmdAddAction(previewCacheAct);
+
     mRasterEffectsVisible = mViewMenu->addAction(
                 tr("Raster Effects", "MenuBar_View"));
     mRasterEffectsVisible->setCheckable(true);

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -27,7 +27,6 @@
 
 #include <QKeyEvent>
 #include <QScrollBar>
-#include <QTimer>
 
 #include "Private/document.h"
 #include "GUI/global.h"
@@ -414,9 +413,6 @@ bool TimelineDockWidget::processKeyPress(QKeyEvent *event)
             mDocument.setActiveSceneFrame(targetFrame);
         }*/
         if (!setNextKeyframe()) { return false; }
-    } else if (key == Qt::Key_M && (mods & Qt::ControlModifier)) {
-        if (state != PreviewState::stopped) { interruptPreview(); }
-        mStepPreviewTimer->start();
     } else {
         return false;
     }

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -138,16 +138,18 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
                               this);
 
     connect(mStepPreviewButton, &QAction::triggered, this, [this]() {
+        const auto scene = *mDocument.fActiveScene;
         if (mStepPreviewTimer->isActive()) {
+            if (scene) { scene->setRenderingPreview(false); }
             mStepPreviewTimer->stop();
             mStepPreviewButton->setIcon(QIcon::fromTheme("play"));
         } else {
             const auto state = RenderHandler::sInstance->currentPreviewState();
             if (state != PreviewState::stopped) { interruptPreview(); }
-            const auto scene = *mDocument.fActiveScene;
             if (scene) {
                 int fps = scene->getFps();
                 mStepPreviewTimer->setInterval(1000 / fps);
+                scene->setRenderingPreview(true);
             }
             mStepPreviewTimer->start();
             mStepPreviewButton->setIcon(QIcon::fromTheme("pause"));

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -147,17 +147,15 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     connect(mLoopButton, &QAction::triggered,
             this, &TimelineDockWidget::setLoop);
 
-    // TODO
     mStepPreviewTimer = new QTimer(this);
-    mStepPreviewButton = new QAction(QIcon::fromTheme("seq_preview"),
+    mStepPreviewButton = new QAction(QIcon::fromTheme("seq_preview"), /* temp icon */
                                      tr("Step Preview"),
                                      this);
     mStepPreviewButton->setCheckable(true);
     connect(mStepPreviewButton, &QAction::triggered, this, [this]() {
-        mPlayBackType = mStepPreviewButton->isChecked() ? PlayBackTypeRealTime : PlayBackTypeCache;
         interruptPreview();
+        mPlayBackType = mStepPreviewButton->isChecked() ? PlayBackTypeRealTime : PlayBackTypeCache;
     });
-    //
 
     mFrameStartSpin = new FrameSpinBox(this);
     mFrameStartSpin->setKeyboardTracking(false);
@@ -253,29 +251,42 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mRenderProgress->setFixedWidth(mCurrentFrameSpin->width());
     mRenderProgress->setFormat(tr("Cache %p%"));
 
-    mToolBar->addWidget(mFrameStartSpin);
-
     eSizesUI::widget.add(mToolBar, [this](const int size) {
         //mRenderProgress->setFixedHeight(eSizesUI::button);
         mToolBar->setIconSize(QSize(size, size));
     });
 
-    QWidget *spacerWidget1 = new QWidget(this);
-    spacerWidget1->setSizePolicy(QSizePolicy::Expanding,
-                                 QSizePolicy::Minimum);
-    mToolBar->addWidget(spacerWidget1);
+    // start layout
+    mToolBar->addWidget(mFrameStartSpin);
+
+    addSpacer();
+
+    addBlankAction();
+    addBlankAction();
 
     mToolBar->addAction(mFrameRewindAct);
     mToolBar->addAction(mPrevKeyframeAct);
     mToolBar->addAction(mNextKeyframeAct);
     mToolBar->addAction(mFrameFastForwardAct);
+
     mRenderProgressAct = mToolBar->addWidget(mRenderProgress);
     mCurrentFrameSpinAct = mToolBar->addWidget(mCurrentFrameSpin);
+
     mToolBar->addAction(mPlayFromBeginningButton);
     mToolBar->addAction(mPlayButton);
     mToolBar->addAction(mStopButton);
     mToolBar->addAction(mLoopButton);
+
+    addBlankAction();
+
     mToolBar->addAction(mStepPreviewButton);
+
+    addSpacer();
+
+    mToolBar->addWidget(mFrameEndSpin);
+    // end layout
+
+    mRenderProgressAct->setVisible(false);
 
     mMainWindow->cmdAddAction(mFrameRewindAct);
     mMainWindow->cmdAddAction(mPrevKeyframeAct);
@@ -285,15 +296,6 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     mMainWindow->cmdAddAction(mPlayButton);
     mMainWindow->cmdAddAction(mStopButton);
     mMainWindow->cmdAddAction(mLoopButton);
-
-    mRenderProgressAct->setVisible(false);
-
-    QWidget *spacerWidget2 = new QWidget(this);
-    spacerWidget2->setSizePolicy(QSizePolicy::Expanding,
-                                 QSizePolicy::Minimum);
-    mToolBar->addWidget(spacerWidget2);
-
-    mToolBar->addWidget(mFrameEndSpin);
 
     mMainLayout->addWidget(mToolBar);
     mMainLayout->addSpacing(2);
@@ -347,6 +349,20 @@ void TimelineDockWidget::showRenderStatus(bool show)
     if (!show) { mRenderProgress->setValue(0); }
     mCurrentFrameSpinAct->setVisible(!show);
     mRenderProgressAct->setVisible(show);
+}
+
+void TimelineDockWidget::addSpacer()
+{
+    const auto spacer = new QWidget(this);
+    spacer->setSizePolicy(QSizePolicy::Expanding,
+                          QSizePolicy::Minimum);
+    mToolBar->addWidget(spacer);
+}
+
+void TimelineDockWidget::addBlankAction()
+{
+    const auto act = mToolBar->addAction(QString());
+    act->setEnabled(false);
 }
 
 void TimelineDockWidget::setLoop(const bool loop)

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -65,7 +65,6 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
     , mRenderProgress(nullptr)
     , mStepPreviewTimer(nullptr)
     , mPlayBackType(PlayBackTypeCache)
-    , mStepPreviewButton(nullptr)
 {
     connect(RenderHandler::sInstance, &RenderHandler::previewFinished,
             this, &TimelineDockWidget::previewFinished);
@@ -148,14 +147,20 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
             this, &TimelineDockWidget::setLoop);
 
     mStepPreviewTimer = new QTimer(this);
-    mStepPreviewButton = new QAction(QIcon::fromTheme("seq_preview"), /* temp icon */
-                                     tr("Step Preview"),
-                                     this);
-    mStepPreviewButton->setCheckable(true);
-    connect(mStepPreviewButton, &QAction::triggered, this, [this]() {
+    const auto previewCache = new QAction(tr("Preview Cache"), this);
+    previewCache->setCheckable(true);
+    previewCache->setChecked(mPlayBackType == PlayBackTypeCache);
+    connect(previewCache, &QAction::triggered,
+            this, [this](bool checked) {
         interruptPreview();
-        mPlayBackType = mStepPreviewButton->isChecked() ? PlayBackTypeRealTime : PlayBackTypeCache;
+        mPlayBackType = checked ? PlayBackTypeCache : PlayBackTypeRealTime;
     });
+
+    const auto extraButton = new QToolButton(this);
+    extraButton->setObjectName("ToolButton");
+    extraButton->setIcon(QIcon::fromTheme("preferences")); // TODO: replace icon
+    extraButton->setPopupMode(QToolButton::InstantPopup);
+    extraButton->addAction(previewCache);
 
     mFrameStartSpin = new FrameSpinBox(this);
     mFrameStartSpin->setKeyboardTracking(false);
@@ -279,7 +284,7 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
 
     addBlankAction();
 
-    mToolBar->addAction(mStepPreviewButton);
+    mToolBar->addWidget(extraButton);
 
     addSpacer();
 

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -94,8 +94,7 @@ private:
     enum PlaybackType
     {
         PlayBackTypeCache,
-        PlayBackTypeRealTime,
-        PlayBackTypeRealTimeOverlay
+        PlayBackTypeRealTime
     };
 
     void setLoop(const bool loop);
@@ -105,7 +104,7 @@ private:
     void renderPreview();
     void pausePreview();
     void resumePreview();
-    void setStepPreviewStop();
+    void setStepPreviewStop(const bool pause = false);
     void setStepPreviewStart();
 
     void updateButtonsVisibility(const CanvasMode mode);

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -91,12 +91,6 @@ public:
     void splitClip();
 
 private:
-    enum PlaybackType
-    {
-        PlayBackTypeCache,
-        PlayBackTypeRealTime
-    };
-
     void setLoop(const bool loop);
     void interruptPreview();
 
@@ -143,7 +137,6 @@ private:
 
     QTimer *mStepPreviewTimer;
 
-    PlaybackType mPlayBackType;
     QList<TimelineWidget*> mTimelineWidgets;
     //AnimationDockWidget *mAnimationDockWidget;
 };

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -146,8 +146,6 @@ private:
     PlaybackType mPlayBackType;
     QList<TimelineWidget*> mTimelineWidgets;
     //AnimationDockWidget *mAnimationDockWidget;
-
-    QAction *mStepPreviewButton;
 };
 
 #endif // BOXESLISTANIMATIONDOCKWIDGET_H

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -91,6 +91,13 @@ public:
     void splitClip();
 
 private:
+    enum PlaybackType
+    {
+        PlayBackTypeCache,
+        PlayBackTypeRealTime,
+        PlayBackTypeRealTimeOverlay
+    };
+
     void setLoop(const bool loop);
     void interruptPreview();
 
@@ -98,6 +105,8 @@ private:
     void renderPreview();
     void pausePreview();
     void resumePreview();
+    void setStepPreviewStop();
+    void setStepPreviewStart();
 
     void updateButtonsVisibility(const CanvasMode mode);
 
@@ -132,6 +141,7 @@ private:
 
     QTimer *mStepPreviewTimer;
 
+    PlaybackType mPlayBackType;
     QList<TimelineWidget*> mTimelineWidgets;
     //AnimationDockWidget *mAnimationDockWidget;
 

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -42,6 +42,7 @@
 #include <QStackedWidget>
 #include <QToolButton>
 #include <QProgressBar>
+#include <QTimer>
 
 #include "smartPointers/ememory.h"
 #include "framerange.h"
@@ -74,6 +75,7 @@ public:
     void previewBeingPlayed();
     void previewBeingRendered();
     void previewPaused();
+    void stepPreview();
 
     bool setPreviewFromStart(PreviewState state);
     bool setNextKeyframe();
@@ -128,8 +130,12 @@ private:
     QAction *mRenderProgressAct;
     QProgressBar *mRenderProgress;
 
+    QTimer *mStepPreviewTimer;
+
     QList<TimelineWidget*> mTimelineWidgets;
     //AnimationDockWidget *mAnimationDockWidget;
+
+    QAction *mStepPreviewButton;
 };
 
 #endif // BOXESLISTANIMATIONDOCKWIDGET_H

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -114,6 +114,9 @@ private:
 
     void showRenderStatus(bool show);
 
+    void addSpacer();
+    void addBlankAction();
+
     Document& mDocument;
     MainWindow* const mMainWindow;
     QStackedWidget* const mTimelineLayout;

--- a/src/core/Private/esettings.cpp
+++ b/src/core/Private/esettings.cpp
@@ -251,6 +251,9 @@ eSettings::eSettings(const int cpuThreads,
                                               "DefaultFillStrokeIndex",
                                                0);
 
+    gSettings << std::make_shared<eBoolSetting>(fPreviewCache,
+                                                "PreviewCache",
+                                                true);
     /*gSettings << std::make_shared<eBoolSetting>(
                      fTimelineAlternateRow,
                      "timelineAlternateRow", true);

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -140,6 +140,8 @@ public:
 
     int fDefaultFillStrokeIndex = 0;
 
+    bool fPreviewCache = true;
+
     // timeline settings
     bool fTimelineAlternateRow = true;
     QColor fTimelineAlternateRowColor = QColor(0, 0, 0, 25);


### PR DESCRIPTION
I promise this is the last feature... it turned out pretty easy and I think it's also handy to have in 1.0:

https://github.com/user-attachments/assets/c39e1b6b-349b-4a56-9113-170244705410

The only thing to discuss (apart from if you want it inside v1.0 indeed, it's your decision) is how the GUI would change to accommodate this new option:
- as it is now, as a different play button: I would design a just outlined Play button to make it different than the normal "rendering" one
- or make it a checkbox next to the loop button (Synfig does this way) where you can choose whether you want to play rendering frames or this new "preview button".

Maybe it is interesting to say that the preview plays at realtime if you computer is capable to do it, if not there is no "dropping frames" feature implemented but I think it's pretty useful and here we don't deal with the cache problems...