### PR TITLE
Fix imported preset path

### DIFF
--- a/src/app/GUI/Expressions/expressiondialog.cpp
+++ b/src/app/GUI/Expressions/expressiondialog.cpp
@@ -926,7 +926,7 @@ void ExpressionDialog::importPreset(const QString& path)
         return;
     }
 
-    const auto expr = mSettings->fExpressions.readExpr(path);
+    auto expr = mSettings->fExpressions.readExpr(path);
     if (mSettings->fExpressions.hasExpr(expr.id)) {
         QMessageBox::warning(this,
                              tr("Expression exists"),
@@ -941,6 +941,7 @@ void ExpressionDialog::importPreset(const QString& path)
                              tr("Save Failed"),
                              tr("Unable to save preset %1.").arg(newPath));
     } else {
+        expr.path = newPath;
         mSettings->fExpressions.addExpr(expr);
         if (!expr.highlighters.isEmpty()) {
             for (const auto &highlight : expr.highlighters) {


### PR DESCRIPTION
When deleting an imported preset, it must delete the copied one (the one in Friction folder) instead of the original one placed in some user folder.