### PR TITLE
SVG Export: added DstOut blend mode

### DIFF
--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -1604,9 +1604,10 @@ eTask* BoundingBox::saveSVGWithTransform(SvgExporter& exp,
                 auto& eleMask = taskPtr->initialize("mask");
                 // check for mask (DstOut)
                 if (ptr->getBlendMode() == SkBlendMode::kDstOut) {
-                    eleMask.appendChild(expPtr->createElement("rect")).toElement().setAttribute("width", "100%");
-                    eleMask.lastChild().toElement().setAttribute("height", "100%");
-                    eleMask.lastChild().toElement().setAttribute("fill", "white");
+                    auto rect = eleMask.appendChild(expPtr->createElement("rect")).toElement();
+                    rect.setAttribute("width", "100%");
+                    rect.setAttribute("height", "100%");
+                    rect.setAttribute("fill", "white");
                 }
                 eleMask.setAttribute("id", QString("%1Mask").arg(AppSupport::filterId(ptr->prp_getName())));
                 eleMask.appendChild(withEffects);

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -1602,6 +1602,12 @@ eTask* BoundingBox::saveSVGWithTransform(SvgExporter& exp,
 
             if (maskId == ptr->prp_getName()) { // move mask to defs
                 auto& eleMask = taskPtr->initialize("mask");
+                // check for mask (DstOut)
+                if (ptr->getBlendMode() == SkBlendMode::kDstOut) {
+                    eleMask.appendChild(expPtr->createElement("rect")).toElement().setAttribute("width", "100%");
+                    eleMask.lastChild().toElement().setAttribute("height", "100%");
+                    eleMask.lastChild().toElement().setAttribute("fill", "white");
+                }
                 eleMask.setAttribute("id", QString("%1Mask").arg(AppSupport::filterId(ptr->prp_getName())));
                 eleMask.appendChild(withEffects);
                 expPtr->addToDefs(eleMask);

--- a/src/core/Boxes/containerbox.cpp
+++ b/src/core/Boxes/containerbox.cpp
@@ -190,11 +190,11 @@ public:
         , mEle(ele)
         , mVisRange(visRange)
     {
-        // check for mask (DstIn)
+        // check for masks (DstIn or DstOut)
         if (mSrc->isLayer()) {
             const auto& boxes = mSrc->getContainedBoxes();
             for (const auto &box : boxes) {
-                if (box->getBlendMode() == SkBlendMode::kDstIn) {
+                if (box->getBlendMode() == SkBlendMode::kDstIn || box->getBlendMode() == SkBlendMode::kDstOut) {
                     mItemMaskId = box->prp_getName();
                     break;
                 }


### PR DESCRIPTION
I've added support for exporting to SVG with `DstOut` layers (inverted masks).

The same way it was important to set your mask layer to **white color** for all the objects into your `DstIn`, now in the "inverted mask" the color has to be **black**.

![mask](https://github.com/user-attachments/assets/9ec7831f-7598-4450-b387-4b7e22e0993e)


I guess you know it (we might have talked about this before) but the behavior or final result of the blending modes are not the same inside Friction and exported SVG. BTW, SVG masks are cooler as they don't just take into account the shapes but the color (white, shades of grey and black) so it's possible to create more complex effects like the one in the previously example. [Here is the Friction project](https://github.com/user-attachments/files/19126892/mask.zip) just in case you want to play with it.

<img width="786" alt="friction_mask" src="https://github.com/user-attachments/assets/40e83cf3-e314-454c-9b6a-1982bfde9205" />

Cheers



