### PR TITLE
Add backspace shortcut to Delete/Remove anything

### DIFF
--- a/src/app/GUI/canvaswindow.cpp
+++ b/src/app/GUI/canvaswindow.cpp
@@ -451,7 +451,7 @@ bool CanvasWindow::handleCutCopyPasteKeyPress(QKeyEvent *event)
                event->key() == Qt::Key_X) {
         if (event->isAutoRepeat()) { return false; }
         (*mActions.cutAction)();
-    } else if (event->key() == Qt::Key_Delete) {
+    } else if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
         (*mActions.deleteAction)();
     } else { return false; }
     return true;

--- a/src/app/GUI/keysview.cpp
+++ b/src/app/GUI/keysview.cpp
@@ -478,7 +478,7 @@ bool KeysView::KFT_keyPressEvent(QKeyEvent *event)
             clearKeySelection();
             container->paste(mCurrentScene->getCurrentFrame(), true,
                              [this](Key* key) { addKeyToSelection(key); });
-         } else if(event->key() == Qt::Key_Delete) {
+         } else if(event->key() == Qt::Key_Delete  || event->key() == Qt::Key_Backspace) {
             if(mGraphViewed) {
                 graphDeletePressed();
             } else {

--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -587,6 +587,7 @@ void MainWindow::setupMenuBar()
         mEditMenu->addAction(qAct);
 #ifndef Q_OS_MAC
         qAct->setShortcut(Qt::Key_Delete);
+        qAct->setShortcut(Qt::Key_Backspace);
 #endif
         mActions.deleteAction->connect(qAct);
         cmdAddAction(qAct);
@@ -1613,7 +1614,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *e)
     const auto focusWidget = QApplication::focusWidget();
     if (type == QEvent::KeyPress) {
         const auto keyEvent = static_cast<QKeyEvent*>(e);
-        if (keyEvent->key() == Qt::Key_Delete && focusWidget) {
+        if (keyEvent->key() == Qt::Key_Delete && focusWidget || keyEvent->key() == Qt::Key_Backspace && focusWidget) {
             mEventFilterDisabled = true;
             const bool widHandled =
                     QCoreApplication::sendEvent(focusWidget, keyEvent);
@@ -1637,7 +1638,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *e)
              key == Qt::Key_X || key == Qt::Key_D)) {
             return processKeyEvent(keyEvent);
         } else if (key == Qt::Key_A || key == Qt::Key_I ||
-                   key == Qt::Key_Delete) {
+                   key == Qt::Key_Delete || key == Qt::Key_Backspace) {
               return processKeyEvent(keyEvent);
         }
     } else if (type == QEvent::KeyRelease) {
@@ -1690,7 +1691,7 @@ bool MainWindow::processBoxesListKeyEvent(QKeyEvent *event)
     } else if (ctrl && event->key() == Qt::Key_X) {
         if (event->isAutoRepeat()) { return false; }
         (*mActions.cutAction)();
-    } else if (event->key() == Qt::Key_Delete) {
+    } else if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
         (*mActions.deleteAction)();
     } else { return false; }
     return true;

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -817,7 +817,7 @@ void BoundingBox::setupCanvasMenu(PropertyMenu * const menu)
 
     menu->addPlainAction(QIcon::fromTheme("trash"), tr("Delete"), [pScene]() {
         pScene->removeSelectedBoxesAndClearList();
-    })->setShortcut(Qt::Key_Delete);
+    })->setShortcut({Qt::Key_Delete, Qt::Key_Backspace});
 
     menu->addSeparator();
 
@@ -1299,7 +1299,7 @@ void BoundingBox::prp_setupTreeViewMenu(PropertyMenu * const menu)
                                                   tr("Are you sure you want to delete selected item(s)?"));
             if (ask != QMessageBox::Yes) { return; }*/
             pScene->removeSelectedBoxesAndClearList();
-        })->setShortcut(Qt::Key_Delete);
+        })->setShortcuts({Qt::Key_Delete, Qt::Key_Backspace});
     }
 
     menu->addSeparator();


### PR DESCRIPTION
I wanted this on Macbooks as they don't have a `Delete` keystroke (unless you simulate it with `fn + backspace`) so I added `Backspace` as an option everywhere I found `Qt::Delete`... I tested it and I think it works and doesn't break anything...

What do you think?

BTW, I already suggested it here: https://github.com/friction2d/friction/issues/453