### PR TITLE
Timeline horizontal zoom (and button)

### DIFF
--- a/src/app/GUI/animationdockwidget.cpp
+++ b/src/app/GUI/animationdockwidget.cpp
@@ -39,6 +39,7 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
     , mSmoothButton(nullptr)
     , mCornerButton(nullptr)
     , mFitToHeightButton(nullptr)
+    , mFitToWidthButton(nullptr)
 {
     setObjectName(QString::fromUtf8("animationDockWidget"));
     setSizePolicy(QSizePolicy::Maximum,
@@ -52,13 +53,9 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
                                 QSizePolicy::Expanding);
     generateEasingActions(easingButton, keysView);
 
-    const auto mFitToWidthButton = new QPushButton(QIcon::fromTheme("zoom_all"),
-                                              QString(), this);
-    mFitToWidthButton->setToolTip(tr("Fit horizontal"));
-    mFitToWidthButton->setFocusPolicy(Qt::NoFocus);
-    mFitToWidthButton->setSizePolicy(QSizePolicy::Expanding,
-                                QSizePolicy::Expanding);
-    connect(mFitToWidthButton, &QPushButton::clicked,
+    mFitToWidthButton = new QAction(QIcon::fromTheme("zoom_horizontal"),
+                                     tr("Fit Horizontal"), this);
+    connect(mFitToWidthButton, &QAction::triggered,
         keysView, &KeysView::keyframeZoomHorizontalAction);
 
     mLineButton = new QAction(QIcon::fromTheme("segmentLine"),
@@ -86,7 +83,7 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
     connect(mCornerButton, &QAction::triggered,
             keysView, &KeysView::graphSetCornerCtrlAction);
 
-    mFitToHeightButton = new QAction(QIcon::fromTheme("zoom"),
+    mFitToHeightButton = new QAction(QIcon::fromTheme("zoom_vertical"),
                                      tr("Fit Vertical"), this);
     connect(mFitToHeightButton, &QAction::triggered,
             keysView, &KeysView::graphResetValueScaleAndMinShownAction);
@@ -114,7 +111,7 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
     addAction(mSmoothButton);
     addAction(mCornerButton);
     addAction(mFitToHeightButton);
-    addWidget(mFitToWidthButton);
+    addAction(mFitToWidthButton);
     //addWidget(valueLines);
 
     eSizesUI::widget.add(this, [this](const int size) {

--- a/src/app/GUI/animationdockwidget.cpp
+++ b/src/app/GUI/animationdockwidget.cpp
@@ -52,6 +52,15 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
                                 QSizePolicy::Expanding);
     generateEasingActions(easingButton, keysView);
 
+    const auto mFitToWidthButton = new QPushButton(QIcon::fromTheme("zoom_all"),
+                                              QString(), this);
+    mFitToWidthButton->setToolTip(tr("Fit horizontal"));
+    mFitToWidthButton->setFocusPolicy(Qt::NoFocus);
+    mFitToWidthButton->setSizePolicy(QSizePolicy::Expanding,
+                                QSizePolicy::Expanding);
+    connect(mFitToWidthButton, &QPushButton::clicked,
+        keysView, &KeysView::keyframeZoomHorizontalAction);
+
     mLineButton = new QAction(QIcon::fromTheme("segmentLine"),
                               tr("Make Segment Line"), this);
     connect(mLineButton, &QAction::triggered,
@@ -105,6 +114,7 @@ AnimationDockWidget::AnimationDockWidget(QWidget *parent,
     addAction(mSmoothButton);
     addAction(mCornerButton);
     addAction(mFitToHeightButton);
+    addWidget(mFitToWidthButton);
     //addWidget(valueLines);
 
     eSizesUI::widget.add(this, [this](const int size) {

--- a/src/app/GUI/animationdockwidget.h
+++ b/src/app/GUI/animationdockwidget.h
@@ -52,6 +52,7 @@ private:
     QAction *mSmoothButton;
     QAction *mCornerButton;
     QAction *mFitToHeightButton;
+    QAction *mFitToWidthButton;
 };
 
 #endif // ANIMATIONDOCKWIDGET_H

--- a/src/app/GUI/graphboxeslist.cpp
+++ b/src/app/GUI/graphboxeslist.cpp
@@ -642,7 +642,29 @@ void KeysView::graphUpdateAfterKeysChanged() {
 
 void KeysView::keyframeZoomHorizontalAction() {
     if(!mCurrentScene) return;
-    const auto range = mCurrentScene->getFrameRange();
+    
+    FrameRange range;
+    if(!mSelectedKeysAnimators.isEmpty()) {
+        int minFrame = INT_MAX;
+        int maxFrame = INT_MIN;
+        
+        for(const auto& anim : mSelectedKeysAnimators) {
+            const int animMin = anim->anim_getLowestAbsFrameForSelectedKey(); 
+            const int animMax = anim->anim_getHighestAbsFrameForSelectedKey();
+            
+            if(animMin < minFrame) minFrame = animMin;
+            if(animMax > maxFrame) maxFrame = animMax;
+        }
+        
+        if(minFrame != INT_MAX && maxFrame != INT_MIN) {
+            range = {minFrame, maxFrame};
+        } else {
+            range = mCurrentScene->getFrameRange();
+        }
+    } else {
+        range = mCurrentScene->getFrameRange(); 
+    }
+
     const int padding = 2;
     const FrameRange newRange = {range.fMin - padding, range.fMax + padding};
     setFramesRange(newRange);

--- a/src/app/GUI/graphboxeslist.cpp
+++ b/src/app/GUI/graphboxeslist.cpp
@@ -639,3 +639,13 @@ void KeysView::graphUpdateAfterKeysChanged() {
     graphResetValueScaleAndMinShown();
     graphUpdateDimensions();
 }
+
+void KeysView::keyframeZoomHorizontalAction() {
+    if(!mCurrentScene) return;
+    const auto range = mCurrentScene->getFrameRange();
+    const int padding = 2;
+    const FrameRange newRange = {range.fMin - padding, range.fMax + padding};
+    setFramesRange(newRange);
+    emit changedViewedFrames(newRange);
+    update();
+}

--- a/src/app/GUI/graphboxeslist.cpp
+++ b/src/app/GUI/graphboxeslist.cpp
@@ -656,7 +656,7 @@ void KeysView::keyframeZoomHorizontalAction() {
             if(animMax > maxFrame) maxFrame = animMax;
         }
         
-        if(minFrame != INT_MAX && maxFrame != INT_MIN) {
+        if(minFrame != INT_MAX && maxFrame != INT_MIN && minFrame < maxFrame) {
             range = {minFrame, maxFrame};
         } else {
             range = mCurrentScene->getFrameRange();

--- a/src/app/GUI/keysview.h
+++ b/src/app/GUI/keysview.h
@@ -117,6 +117,7 @@ public:
     void graphRemoveViewedAnimator(GraphAnimator * const animator);
     void clearHoveredMovable();
     bool KFT_keyPressEvent(QKeyEvent *event);
+    void keyframeZoomHorizontalAction();
 protected:
     ValueInput mValueInput;
 

--- a/src/core/Animators/animator.cpp
+++ b/src/core/Animators/animator.cpp
@@ -714,6 +714,17 @@ int Animator::anim_getLowestAbsFrameForSelectedKey() {
     return lowestKey;
 }
 
+int Animator::anim_getHighestAbsFrameForSelectedKey() {
+    int highestKey = FrameRange::EMIN;
+    for(const auto& key : anim_mSelectedKeys) {
+        int keyAbsFrame = key->getAbsFrame();
+        if(keyAbsFrame > highestKey) {
+            highestKey = keyAbsFrame;
+        }
+    }
+    return highestKey;
+}
+
 void Animator::saveSVG(SvgExporter& exp,
                        QDomElement& parent,
                        const FrameRange& visRange,

--- a/src/core/Animators/animator.h
+++ b/src/core/Animators/animator.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 #
 # Friction - https://friction.graphics
 #

--- a/src/core/Animators/animator.h
+++ b/src/core/Animators/animator.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 #
 # Friction - https://friction.graphics
 #
@@ -180,6 +180,7 @@ public:
     void anim_deleteCurrentKeyAction();
 
     int anim_getLowestAbsFrameForSelectedKey();
+    int anim_getHighestAbsFrameForSelectedKey();
 
     const QList<Key*>& anim_getSelectedKeys() const {
         return anim_mSelectedKeys;


### PR DESCRIPTION
Using the new icons PRd to https://github.com/friction2d/friction-icon-theme/pull/29

This feature adds a zoom icon for zooming vertical:
- if less than 2 keyframes selected: it zooms to scene range
- if 2 or more keyframes selected: it zooms to the keyframes selection

https://github.com/user-attachments/assets/623a3668-ddb9-4460-a5aa-22178271dc83

I hope you like it 😊 