### PR TITLE
Rewind / Fast Forward by quarters

### DIFF
--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -94,9 +94,10 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
             this, [this]() {
         const auto scene = *mDocument.fActiveScene;
         if (!scene) { return; }
-        if (QApplication::keyboardModifiers() & Qt::ShiftModifier) {
+        if ((QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) 
+            == (Qt::ShiftModifier | Qt::AltModifier)) { // Go to previous scene quarter
             jumpToIntermediateFrame(false);
-        } else {
+        } else { // Go to First Frame
             scene->anim_setAbsFrame(scene->getFrameRange().fMin);
             mDocument.actionFinished();
         }
@@ -113,9 +114,10 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
             this, [this]() {
         const auto scene = *mDocument.fActiveScene;
         if (!scene) { return; }
-        if (QApplication::keyboardModifiers() & Qt::ShiftModifier) {
+        if ((QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) 
+        == (Qt::ShiftModifier | Qt::AltModifier)) { // Go to next scene quarter
             jumpToIntermediateFrame(true);
-        } else {
+        } else { // Go to Last Frame
             scene->anim_setAbsFrame(scene->getFrameRange().fMax);
             mDocument.actionFinished();
         }
@@ -399,10 +401,18 @@ bool TimelineDockWidget::processKeyPress(QKeyEvent *event)
             case Qt::Key_O: setOut(); break;
             default:;
         }
-    } else if (key == Qt::Key_Right && !(mods & Qt::ControlModifier)) { // next frame
-        mDocument.incActiveSceneFrame();
-    } else if (key == Qt::Key_Left && !(mods & Qt::ControlModifier)) { // previous frame
-        mDocument.decActiveSceneFrame();
+    } else if (key == Qt::Key_Right && !(mods & Qt::ControlModifier)) {
+        if ((mods & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier)) { // jump to next scene quarter
+            jumpToIntermediateFrame(true);
+        } else { // next frame
+            mDocument.incActiveSceneFrame();
+        }
+    } else if (key == Qt::Key_Left && !(mods & Qt::ControlModifier)) {
+        if ((mods & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier)) { // jump to previous scene quarter
+            jumpToIntermediateFrame(false);
+        } else { // previous frame
+            mDocument.decActiveSceneFrame();
+        }
     } else if (key == Qt::Key_Down && !(mods & Qt::ControlModifier)) { // previous keyframe
         /*const auto scene = *mDocument.fActiveScene;
         if (!scene) { return false; }

--- a/src/app/GUI/timelinedockwidget.cpp
+++ b/src/app/GUI/timelinedockwidget.cpp
@@ -94,8 +94,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
             this, [this]() {
         const auto scene = *mDocument.fActiveScene;
         if (!scene) { return; }
-        if ((QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) 
-            == (Qt::ShiftModifier | Qt::AltModifier)) { // Go to previous scene quarter
+        const bool jumpFrame = (QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier);
+        if (jumpFrame) { // Go to previous scene quarter
             jumpToIntermediateFrame(false);
         } else { // Go to First Frame
             scene->anim_setAbsFrame(scene->getFrameRange().fMin);
@@ -114,8 +114,8 @@ TimelineDockWidget::TimelineDockWidget(Document& document,
             this, [this]() {
         const auto scene = *mDocument.fActiveScene;
         if (!scene) { return; }
-        if ((QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) 
-        == (Qt::ShiftModifier | Qt::AltModifier)) { // Go to next scene quarter
+        const bool jumpFrame = (QApplication::keyboardModifiers() & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier);
+        if (jumpFrame) { // Go to next scene quarter
             jumpToIntermediateFrame(true);
         } else { // Go to Last Frame
             scene->anim_setAbsFrame(scene->getFrameRange().fMax);
@@ -367,6 +367,7 @@ bool TimelineDockWidget::processKeyPress(QKeyEvent *event)
     const int key = event->key();
     const auto mods = event->modifiers();
     const auto state = RenderHandler::sInstance->currentPreviewState();
+    const bool jumpFrame = (mods & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier);
     if (key == Qt::Key_Escape) { // stop playback
         if (state != PreviewState::stopped ||
             mStepPreviewTimer->isActive()) { interruptPreview(); }
@@ -402,13 +403,13 @@ bool TimelineDockWidget::processKeyPress(QKeyEvent *event)
             default:;
         }
     } else if (key == Qt::Key_Right && !(mods & Qt::ControlModifier)) {
-        if ((mods & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier)) { // jump to next scene quarter
+        if (jumpFrame) { // jump to next scene quarter
             jumpToIntermediateFrame(true);
         } else { // next frame
             mDocument.incActiveSceneFrame();
         }
     } else if (key == Qt::Key_Left && !(mods & Qt::ControlModifier)) {
-        if ((mods & (Qt::ShiftModifier | Qt::AltModifier)) == (Qt::ShiftModifier | Qt::AltModifier)) { // jump to previous scene quarter
+        if (jumpFrame) { // jump to previous scene quarter
             jumpToIntermediateFrame(false);
         } else { // previous frame
             mDocument.decActiveSceneFrame();

--- a/src/app/GUI/timelinedockwidget.h
+++ b/src/app/GUI/timelinedockwidget.h
@@ -93,6 +93,7 @@ public:
 private:
     void setLoop(const bool loop);
     void interruptPreview();
+    void jumpToIntermediateFrame(bool forward);
 
     void playPreview();
     void renderPreview();


### PR DESCRIPTION
I find this one pretty handy, at least for simple web animations. It's also transparent for users that don't want to use it as it is "hidden" in rewind and fastforward buttons.

Rewind and fastforward gets step by scene range quarters if pressing `shift` modifier.

https://github.com/user-attachments/assets/ec351214-2212-432d-8725-c9ee8a4667f9

Cheers