### PR TITLE
Support paste SVG from clipboard

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -39,6 +39,8 @@
 #include <QSpacerItem>
 #include <QMargins>
 #include <iostream>
+#include <QClipboard>
+#include <QMimeData>
 
 #include "GUI/edialogs.h"
 #include "dialogs/applyexpressiondialog.h"
@@ -568,6 +570,23 @@ void MainWindow::setupMenuBar()
 #endif
         mActions.pasteAction->connect(qAct);
         cmdAddAction(qAct);
+    }
+
+    { // import (paste) SVG from clipboard
+        mEditMenu->addAction(QIcon::fromTheme("paste"),
+                             tr("Paste from Clipboard"),
+                             [this]() {
+            const auto clipboard = QGuiApplication::clipboard();
+            if (clipboard) {
+                const auto mime = clipboard->mimeData();
+                qDebug() << mime->formats() << mime->text();
+                if (mime->hasText() && mime->text().contains("<svg")) {
+                    const QString svg = mime->text();
+                    try { mActions.importClipboard(svg); }
+                    catch (const std::exception& e) { gPrintExceptionCritical(e); }
+                }
+            }
+        }, QKeySequence(tr("Ctrl+Shift+V")));
     }
 
     {

--- a/src/core/actions.h
+++ b/src/core/actions.h
@@ -101,6 +101,12 @@ public:
                             const int insertId = 0,
                             const QPointF &relDropPos = QPointF(0, 0),
                             const int frame = 0);
+    eBoxOrSound* importClipboard(const QString &content);
+    eBoxOrSound* importClipboard(const QString &content,
+                                 ContainerBox * const target,
+                                 const int insertId = 0,
+                                 const QPointF &relDropPos = QPointF(0, 0),
+                                 const int frame = 0);
     eBoxOrSound *linkFile(const QString &path);
 //
     void setMovePathMode();


### PR DESCRIPTION
Paste SVG from clipboard (Shift+ctrl/cmd+v).

https://github.com/user-attachments/assets/0049dc22-ef5f-4153-9e70-73a282b25170

Only tested on Linux and macOS.

**NOTE:** Inkscape and the clipboard is broken on macOS, you will not be able to paste from Inkscape (it produces an raster image and HTML junk), not our problem (https://gitlab.com/inkscape/inbox/-/issues/10924).