### PR TITLE
Force constant FPS for rendered videos

### DIFF
--- a/src/core/videoencoder.cpp
+++ b/src/core/videoencoder.cpp
@@ -203,6 +203,9 @@ static void addVideoStream(OutputStream * const ost,
     ost->fStream->time_base = renSettings.fTimeBase;
     c->time_base       = ost->fStream->time_base;
 
+    ost->fStream->r_frame_rate = av_inv_q(renSettings.fTimeBase);
+    ost->fStream->avg_frame_rate = ost->fStream->r_frame_rate;
+
     if (VideoEncoder::isValidProfile(codec,
                                      outSettings.fVideoProfile)) {
         c->profile = outSettings.fVideoProfile;


### PR DESCRIPTION
It's a pretty simple fix but I think it solves the problem as not just kdenlive but HandBrake and ffprobe are reading Friction rendered video with not a rounded and exact/constant FPS as the one set at your scene.

I'm not expert in this field so I used chatGPT to help me so, please, have a look at it if this is a nice solution o not as it works for kdenlive, HandBrake and ffprobe but I don't know if somehow we could be breaking the videos....

ChatGPT says this about the proposed fix:
```cpp
// Sets the stream’s "actual" framerate. av_inv_q() inverts the timebase fraction
// (e.g., if timebase is 1/60, this gives 60/1, which is 60fps)
ost->fStream->r_frame_rate = av_inv_q(renSettings.fTimeBase);

// Sets the average framerate to be equal to the actual framerate.
// This is important so that the player knows the video has a constant framerate
ost->fStream->avg_frame_rate = ost->fStream->r_frame_rate;
```
```
### Why are these lines important?

- `r_frame_rate` represents the actual/desired framerate of the video.
- `avg_frame_rate` represents the average frames per second.
- By setting both to the exact same value, we tell FFmpeg we want a constant framerate.
- Using `av_inv_q()` ensures we get the exact framerate from the timebase.

### Why is this solution better than the previous one?

- It doesn’t modify the encoder’s behavior.
- It uses FFmpeg’s native properties to handle framerates.
- It’s similar to what FFmpeg does internally when using `-r 60` on the command line.
- It doesn’t require additional flags or configurations.

### Notes

That’s why exported videos should now show exactly **60 FPS** instead of **60.20 FPS** or similar values.

```