### PR TITLE
UX: Draw/Stroke/Fill better workflow

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1805,6 +1805,18 @@ void MainWindow::writeSettings()
     AppSupport::setSettings("ui", "geometry", saveGeometry());
     AppSupport::setSettings("ui", "maximized", isMaximized());
     AppSupport::setSettings("ui", "fullScreen", isFullScreen());
+
+    AppSupport::setSettings("FillStroke", "LastStrokeColor",
+                            eSettings::instance().fLastUsedStrokeColor);
+    AppSupport::setSettings("FillStroke", "LastStrokeWidth",
+                            eSettings::instance().fLastUsedStrokeWidth);
+    AppSupport::setSettings("FillStroke", "LastStrokeFlat",
+                            eSettings::instance().fLastStrokeFlatEnabled);
+
+    AppSupport::setSettings("FillStroke", "LastFillColor",
+                            eSettings::instance().fLastUsedFillColor);
+    AppSupport::setSettings("FillStroke", "LastFillFlat",
+                            eSettings::instance().fLastFillFlatEnabled);
 }
 
 bool MainWindow::isEnabled()

--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1433,7 +1433,7 @@ void MainWindow::askRestoreFillStrokeDefault()
     auto settings = eSettings::sInstance;
     settings->fLastFillFlatEnabled = false;
     settings->fLastStrokeFlatEnabled = true;
-    settings->fLastUsedFillColor = Qt::black;
+    settings->fLastUsedFillColor = Qt::white;
     settings->fLastUsedStrokeColor = ThemeSupport::getThemeObjectColor();
     settings->fLastUsedStrokeWidth = 10.;
 }

--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1139,7 +1139,9 @@ void MainWindow::setupMenuBar()
     help->addAction(QIcon::fromTheme("renderlayers"),
                     tr("Reinstall default Expressions Presets"),
                     this, &MainWindow::askInstallExpressionsPresets);
-
+    help->addAction(QIcon::fromTheme("color"),
+                    tr("Restore default fill and stroke"),
+                    this, &MainWindow::askRestoreFillStrokeDefault);
 
     // toolbar actions
     mToolbar->addAction(newAct);
@@ -1419,6 +1421,21 @@ void MainWindow::askInstallExpressionsPresets()
                                                  "<p style='font-weight: normal;font-style: italic'>Note that:<ul><li>any user modification to default presets will be removed.</li><li>a restart of the application is required to install them all.</li></ul></p>"));
     if (result != QMessageBox::Yes) { return; }
     AppSupport::setSettings("settings", "firstRunExprPresets", true);
+}
+
+void MainWindow::askRestoreFillStrokeDefault()
+{
+    const auto result = QMessageBox::question(this,
+                                              tr("Restore default fill and stroke?"),
+                                              tr("Are you sure you want to restore fill and stroke defaults?"));
+    if (result != QMessageBox::Yes) { return; }
+
+    auto settings = eSettings::sInstance;
+    settings->fLastFillFlatEnabled = false;
+    settings->fLastStrokeFlatEnabled = true;
+    settings->fLastUsedFillColor = Qt::black;
+    settings->fLastUsedStrokeColor = ThemeSupport::getThemeObjectColor();
+    settings->fLastUsedStrokeWidth = 10.;
 }
 
 void MainWindow::openWelcomeDialog()

--- a/src/app/GUI/mainwindow.h
+++ b/src/app/GUI/mainwindow.h
@@ -398,6 +398,7 @@ private:
     void initRenderPresets(const bool reinstall = false);
     void askInstallRenderPresets();
     void askInstallExpressionsPresets();
+    void askRestoreFillStrokeDefault();
 
     QLabel *mColorPickLabel;
 

--- a/src/core/Animators/outlinesettingsanimator.h
+++ b/src/core/Animators/outlinesettingsanimator.h
@@ -25,8 +25,10 @@
 
 #ifndef OUTLINESETTINGSANIMATOR_H
 #define OUTLINESETTINGSANIMATOR_H
+
 #include "paintsettingsanimator.h"
 #include "Animators/brushsettingsanimator.h"
+#include "Private/esettings.h"
 
 class CORE_EXPORT OutlineSettingsAnimator : public PaintSettingsAnimator {
     typedef qCubicSegment1DAnimator::Action SegAction;
@@ -129,6 +131,7 @@ private:
     qsptr<BrushSettingsAnimator> mBrushSettings =
             enve::make_shared<BrushSettingsAnimator>();
     qsptr<QrealAnimator> mLineWidth =
-            enve::make_shared<QrealAnimator>(10, 0, 999, 1, "thickness");
+            enve::make_shared<QrealAnimator>(eSettings::instance().fLastUsedStrokeWidth,
+                                             0, 999, 1, "thickness");
 };
 #endif // OUTLINESETTINGSANIMATOR_H

--- a/src/core/Animators/paintsettingsanimator.cpp
+++ b/src/core/Animators/paintsettingsanimator.cpp
@@ -410,8 +410,9 @@ void PaintSettingsAnimator::showHideChildrenBeforeChangingPaintType(
         ca_addChild(mColor);
 }
 
-void PaintSettingsAnimator::setPaintType(const PaintType paintType) {
-    if(paintType == mPaintType) return;
+void PaintSettingsAnimator::setPaintType(const PaintType paintType)
+{
+    if (paintType == mPaintType) { return; }
     {
         UndoRedo ur;
         const auto oldValue = mPaintType;
@@ -433,6 +434,8 @@ void PaintSettingsAnimator::setPaintType(const PaintType paintType) {
     prp_afterWholeInfluenceRangeChanged();
 
     SWT_setDisabled(paintType == PaintType::NOPAINT);
+
+    emit paintTypeChanged(mPaintType);
 }
 
 ColorAnimator *PaintSettingsAnimator::getColorAnimator() {

--- a/src/core/Animators/paintsettingsanimator.h
+++ b/src/core/Animators/paintsettingsanimator.h
@@ -47,6 +47,7 @@ class AdvancedTransformAnimator;
 struct UpdatePaintSettings;
 
 class CORE_EXPORT PaintSettingsAnimator : public ComplexAnimator {
+    Q_OBJECT
 protected:
     PaintSettingsAnimator(const QString &name,
                           BoundingBox * const parent);
@@ -86,6 +87,10 @@ public:
                             UpdatePaintSettings& settings);
     void duplicatePaintSettingsNotAnim(PaintSettingsAnimator * const settings);
     void applyTransform(const QMatrix& transform);
+
+signals:
+    void paintTypeChanged(const PaintType &type);
+
 protected:
     void saveSVG(SvgExporter& exp,
                  QDomElement& parent,

--- a/src/core/Boxes/pathbox.cpp
+++ b/src/core/Boxes/pathbox.cpp
@@ -75,7 +75,7 @@ PathBox::PathBox(const QString &name, const eBoxType type) :
     mStrokeGradientPoints = mFillSettings->getGradientPoints();
 
     mStrokeSettings->setPaintType(PaintType::FLATPAINT);
-    mStrokeSettings->setCurrentColor(eSettings::sInstance->fLastUsedStrokeColor);
+    mStrokeSettings->setCurrentColor(eSettings::instance().fLastUsedStrokeColor);
 
     ca_prependChild(mPathEffectsAnimators.get(), mFillSettings);
     ca_prependChild(mPathEffectsAnimators.get(), mStrokeSettings);

--- a/src/core/Boxes/pathbox.cpp
+++ b/src/core/Boxes/pathbox.cpp
@@ -75,7 +75,7 @@ PathBox::PathBox(const QString &name, const eBoxType type) :
     mStrokeGradientPoints = mFillSettings->getGradientPoints();
 
     mStrokeSettings->setPaintType(PaintType::FLATPAINT);
-    mStrokeSettings->setCurrentColor(ThemeSupport::getThemeObjectColor());
+    mStrokeSettings->setCurrentColor(eSettings::sInstance->fLastUsedStrokeColor);
 
     ca_prependChild(mPathEffectsAnimators.get(), mFillSettings);
     ca_prependChild(mPathEffectsAnimators.get(), mStrokeSettings);

--- a/src/core/Boxes/pathbox.cpp
+++ b/src/core/Boxes/pathbox.cpp
@@ -81,12 +81,16 @@ PathBox::PathBox(const QString &name,
     mStrokeSettings = enve::make_shared<OutlineSettingsAnimator>(this);
     mStrokeGradientPoints = mFillSettings->getGradientPoints();
 
+    bool fillFlat = eSettings::instance().fLastFillFlatEnabled;
+    bool strokeFlat = eSettings::instance().fLastStrokeFlatEnabled;
+    if (!fillFlat && !strokeFlat) { strokeFlat = true; }
+
     switch (type) {
     case eBoxType::circle:
     case eBoxType::rectangle:
-        mFillSettings->setPaintType(eSettings::instance().fLastFillFlatEnabled ?
+        mFillSettings->setPaintType(fillFlat ?
                                     PaintType::FLATPAINT : PaintType::NOPAINT);
-        mStrokeSettings->setPaintType(eSettings::instance().fLastStrokeFlatEnabled ?
+        mStrokeSettings->setPaintType(strokeFlat ?
                                       PaintType::FLATPAINT : PaintType::NOPAINT);
         break;
     default:

--- a/src/core/Boxes/textbox.cpp
+++ b/src/core/Boxes/textbox.cpp
@@ -39,9 +39,10 @@
 #include "svgexporter.h"
 #include "Private/esettings.h"
 
-TextBox::TextBox() : PathBox("Text", eBoxType::text) {
+TextBox::TextBox()
+    : PathBox("Text", eBoxType::text)
+{
     mFillSettings->setPaintType(PaintType::FLATPAINT);
-    mFillSettings->setCurrentColor(QColor(Qt::white));
     mStrokeSettings->setPaintType(PaintType::NOPAINT);
 
     const auto pathsUpdater = [this](const UpdateReason reason) {

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -171,6 +171,13 @@ public:
     // last used stoke size
     qreal fLastUsedStrokeWidth = 10.;
 
+    // last used fill color
+    QColor fLastUsedFillColor = Qt::black;
+
+    // last fill/stroke state
+    bool fLastFillFlatEnabled = false;
+    bool fLastStrokeFlatEnabled = true;
+
 signals:
     void settingsChanged();
 

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -178,7 +178,7 @@ public:
     // last used fill color
     QColor fLastUsedFillColor = AppSupport::getSettings("FillStroke",
                                                         "LastFillColor",
-                                                        QColor(Qt::black)).value<QColor>();
+                                                        QColor(Qt::white)).value<QColor>();
 
     // last fill/stroke state
     bool fLastFillFlatEnabled = AppSupport::getSettings("FillStroke",

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -165,6 +165,9 @@ public:
     // expressions presets
     Friction::Core::ExpressionPresets fExpressions;
 
+    // last used stroke color
+    QColor fLastUsedStrokeColor = ThemeSupport::getThemeObjectColor();
+
 signals:
     void settingsChanged();
 

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -168,6 +168,9 @@ public:
     // last used stroke color
     QColor fLastUsedStrokeColor = ThemeSupport::getThemeObjectColor();
 
+    // last used stoke size
+    qreal fLastUsedStrokeWidth = 10.;
+
 signals:
     void settingsChanged();
 

--- a/src/core/Private/esettings.h
+++ b/src/core/Private/esettings.h
@@ -166,17 +166,27 @@ public:
     Friction::Core::ExpressionPresets fExpressions;
 
     // last used stroke color
-    QColor fLastUsedStrokeColor = ThemeSupport::getThemeObjectColor();
+    QColor fLastUsedStrokeColor = AppSupport::getSettings("FillStroke",
+                                                          "LastStrokeColor",
+                                                          ThemeSupport::getThemeObjectColor()).value<QColor>();
 
     // last used stoke size
-    qreal fLastUsedStrokeWidth = 10.;
+    qreal fLastUsedStrokeWidth = AppSupport::getSettings("FillStroke",
+                                                         "LastStrokeWidth",
+                                                         10.).toDouble();
 
     // last used fill color
-    QColor fLastUsedFillColor = Qt::black;
+    QColor fLastUsedFillColor = AppSupport::getSettings("FillStroke",
+                                                        "LastFillColor",
+                                                        QColor(Qt::black)).value<QColor>();
 
     // last fill/stroke state
-    bool fLastFillFlatEnabled = false;
-    bool fLastStrokeFlatEnabled = true;
+    bool fLastFillFlatEnabled = AppSupport::getSettings("FillStroke",
+                                                        "LastFillFlat",
+                                                        false).toBool();
+    bool fLastStrokeFlatEnabled = AppSupport::getSettings("FillStroke",
+                                                          "LastStrokeFlat",
+                                                          true).toBool();
 
 signals:
     void settingsChanged();

--- a/src/core/appsupport.cpp
+++ b/src/core/appsupport.cpp
@@ -1063,3 +1063,27 @@ const QString AppSupport::filterId(const QString &input)
 {
     return QString(input).simplified().replace(" ", "");
 }
+
+const QColor AppSupport::adjustColorVisibility(const QColor &color,
+                                               const QColor &background)
+{
+    qDebug() << "compare" << "color" << color << "background" << background;
+
+    if (color.alpha() == 0) { // if no alpha return gray
+        return QColor(128, 128, 128);
+    }
+    if (color == background &&
+        (color == Qt::black || color == Qt::white)) {
+        // if same color and that is white or black return gray
+        return QColor(128, 128, 128, color.alpha());
+    }
+
+    qreal luminanceColor = color.valueF();
+    qreal luminanceBackground = background.valueF();
+
+    if (std::abs(luminanceColor - luminanceBackground) < 0.4) { // return a darker/lighter color
+        if (luminanceBackground > 0.5) { return color.darker(150); }
+        else { return color.lighter(150); }
+    }
+    return color;
+}

--- a/src/core/appsupport.h
+++ b/src/core/appsupport.h
@@ -138,6 +138,8 @@ public:
     static void printHelp(const bool &isRenderer);
     static void handlePortableFirstRun();
     static const QString filterId(const QString &input);
+    static const QColor adjustColorVisibility(const QColor &color,
+                                              const QColor &background);
 };
 
 #endif // APPSUPPORT_H

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -335,7 +335,11 @@ void Canvas::renderSk(SkCanvas* const canvas,
         paint.setAntiAlias(true);
 
         const auto& pts = mDrawPath.smoothPts();
-        paint.setARGB(255, 0, 125, 255);
+        const auto drawColor = eSettings::sInstance->fLastUsedStrokeColor;
+        paint.setARGB(255,
+                      drawColor.red(),
+                      drawColor.green(),
+                      drawColor.blue());
         const SkScalar ptSize = 0.25*nodeSize;
         for(const auto& pt : pts) {
             canvas->drawCircle(pt.x(), pt.y(), ptSize, paint);

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -335,7 +335,7 @@ void Canvas::renderSk(SkCanvas* const canvas,
         paint.setAntiAlias(true);
 
         const auto& pts = mDrawPath.smoothPts();
-        const auto drawColor = eSettings::sInstance->fLastUsedStrokeColor;
+        const auto drawColor = eSettings::instance().fLastUsedStrokeColor;
         paint.setARGB(255,
                       drawColor.red(),
                       drawColor.green(),

--- a/src/core/canvasmouseevents.cpp
+++ b/src/core/canvasmouseevents.cpp
@@ -170,6 +170,10 @@ void Canvas::mouseReleaseEvent(const eMouseEvent &e)
             drawPathClear();
             clearSelectionAction();
             break;
+        case CanvasMode::circleCreate:
+        case CanvasMode::rectCreate:
+            clearSelectionAction();
+            break;
         case CanvasMode::pickFillStroke:
             applyPixelColor(pickPixelColor(e.fGlobalPos), false);
             break;

--- a/src/core/canvasmouseevents.cpp
+++ b/src/core/canvasmouseevents.cpp
@@ -168,6 +168,7 @@ void Canvas::mouseReleaseEvent(const eMouseEvent &e)
             break;
         case CanvasMode::drawPath:
             drawPathClear();
+            clearSelectionAction();
             break;
         case CanvasMode::pickFillStroke:
             applyPixelColor(pickPixelColor(e.fGlobalPos), false);

--- a/src/ui/dialogs/scenesettingsdialog.cpp
+++ b/src/ui/dialogs/scenesettingsdialog.cpp
@@ -28,6 +28,7 @@
 #include "GUI/coloranimatorbutton.h"
 #include "appsupport.h"
 #include "Private/document.h"
+#include "Private/esettings.h"
 
 SceneSettingsDialog::SceneSettingsDialog(Canvas * const canvas,
                                          QWidget * const parent)
@@ -319,6 +320,7 @@ void SceneSettingsDialog::applySettingsToCanvas(Canvas * const canvas) const
     canvas->setCanvasSize(getCanvasWidth(), getCanvasHeight());
     canvas->setFps(getFps());
     canvas->setFrameRange(getFrameRange());
+
     if (mSaveAsDefault) {
         const bool saveDef = mSaveAsDefault->isChecked();
         AppSupport::setSettings("scene", "SaveDefault", saveDef);
@@ -338,6 +340,13 @@ void SceneSettingsDialog::applySettingsToCanvas(Canvas * const canvas) const
                                                                          getCanvasHeight()); }
     if (canvas != mTargetCanvas) {
         canvas->getBgColorAnimator()->setColor(mBgColorButton->color());
+
+        // Adjust default fill/stroke color to background color
+        auto settings = eSettings::sInstance;
+        settings->fLastUsedFillColor = AppSupport::adjustColorVisibility(eSettings::instance().fLastUsedFillColor,
+                                                                         mBgColorButton->color());
+        settings->fLastUsedStrokeColor = AppSupport::adjustColorVisibility(eSettings::instance().fLastUsedStrokeColor,
+                                                                           mBgColorButton->color());
     }
 }
 

--- a/src/ui/widgets/fillstrokesettings.cpp
+++ b/src/ui/widgets/fillstrokesettings.cpp
@@ -664,8 +664,17 @@ PaintType FillStrokeSettingsWidget::getCurrentPaintTypeVal()
 
 void FillStrokeSettingsWidget::setCurrentPaintTypeVal(const PaintType paintType)
 {
-    if (mTarget == PaintSetting::FILL) { mCurrentFillPaintType = paintType; }
-    else { mCurrentStrokePaintType = paintType; }
+    if (mTarget == PaintSetting::FILL) {
+        if (!mCurrentFillColorAnimator && (mCurrentFillPaintType != paintType)) {
+            eSettings::sInstance->fLastFillFlatEnabled = (paintType == PaintType::FLATPAINT);
+        }
+        mCurrentFillPaintType = paintType;
+    } else {
+        if (!mCurrentStrokeColorAnimator && (mCurrentStrokePaintType != paintType)) {
+            eSettings::sInstance->fLastStrokeFlatEnabled = (paintType == PaintType::FLATPAINT);
+        }
+        mCurrentStrokePaintType = paintType;
+    }
 }
 
 QColor FillStrokeSettingsWidget::getColorVal()

--- a/src/ui/widgets/fillstrokesettings.cpp
+++ b/src/ui/widgets/fillstrokesettings.cpp
@@ -127,6 +127,7 @@ FillStrokeSettingsWidget::FillStrokeSettingsWidget(Document &document,
     connect(mLineWidthSpin, &QrealAnimatorValueSlider::valueEdited,
             actions, [actions](const qreal value) {
         actions->strokeWidthAction(QrealAction::sMakeSet(value));
+        eSettings::sInstance->fLastUsedStrokeWidth = value;
     });
     connect(mLineWidthSpin, &QrealAnimatorValueSlider::editingFinished,
             actions, [actions]() {

--- a/src/ui/widgets/fillstrokesettings.cpp
+++ b/src/ui/widgets/fillstrokesettings.cpp
@@ -599,6 +599,12 @@ void FillStrokeSettingsWidget::colorSettingReceived(const ColorSetting &colorSet
         paintSetting << std::make_shared<ColorPaintSetting>(mTarget, colorSetting);
         scene->applyPaintSettingToSelected(paintSetting);
     }
+
+    if (mTarget == PaintSetting::OUTLINE &&
+        getCurrentPaintTypeVal() == PaintType::FLATPAINT) {
+        // store as last used stroke color
+        eSettings::sInstance->fLastUsedStrokeColor = colorSetting.getColor();
+    }
 }
 
 void FillStrokeSettingsWidget::connectGradient()

--- a/src/ui/widgets/fillstrokesettings.cpp
+++ b/src/ui/widgets/fillstrokesettings.cpp
@@ -606,6 +606,12 @@ void FillStrokeSettingsWidget::colorSettingReceived(const ColorSetting &colorSet
         // store as last used stroke color
         eSettings::sInstance->fLastUsedStrokeColor = colorSetting.getColor();
     }
+
+    if (mTarget == PaintSetting::FILL &&
+        getCurrentPaintTypeVal() == PaintType::FLATPAINT) {
+        // store as last used fill color
+        eSettings::sInstance->fLastUsedFillColor = colorSetting.getColor();
+    }
 }
 
 void FillStrokeSettingsWidget::connectGradient()


### PR DESCRIPTION
Based on feedback in https://github.com/orgs/friction2d/discussions/488 I did some changes to the stroke workflow.

* Stroke color and width are now stored for reuse on new draw/stroke action (rectangle/circle)
* Right-click in draw mode will unselect last draw action (or any selected)
  * This allows for changes to color/width during draw session

@pgilfernandez @AptGetMe


https://github.com/user-attachments/assets/a741f7f1-6480-4236-a153-bdf40f771aa9

