### PR TITLE
[Dash effect] New parameters added

### DIFF
--- a/src/core/PathEffects/dashpatheffect.cpp
+++ b/src/core/PathEffects/dashpatheffect.cpp
@@ -32,11 +32,11 @@ DashPathEffect::DashPathEffect() :
     mSize->setValueRange(0.1, 9999.999);
     mSize->setCurrentBaseValue(1);
 
-    mDashLength = enve::make_shared<QrealAnimator>("dash length");
+    mDashLength = enve::make_shared<QrealAnimator>("length");
     mDashLength->setValueRange(0.1, 9999.999);
     mDashLength->setCurrentBaseValue(10);
 
-    mSpaceLength = enve::make_shared<QrealAnimator>("space length");
+    mSpaceLength = enve::make_shared<QrealAnimator>("spacing");
     mSpaceLength->setValueRange(0.1, 9999.999);
     mSpaceLength->setCurrentBaseValue(5);
 

--- a/src/core/PathEffects/dashpatheffect.h
+++ b/src/core/PathEffects/dashpatheffect.h
@@ -35,6 +35,9 @@ public:
     stdsptr<PathEffectCaller> getEffectCaller(
             const qreal relFrame, const qreal influence) const;
 private:
+    qsptr<QrealAnimator> mDashLength;
+    qsptr<QrealAnimator> mSpaceLength;
+    qsptr<QrealAnimator> mOffset;
     qsptr<QrealAnimator> mSize;
 };
 


### PR DESCRIPTION
As requested in https://github.com/friction2d/friction/issues/503 I have added some new parameters to control a `outline base` dash effect:
- `size` changes to `scale`
- `length`
- `spacing`
- `offset`

I did not implemented `number of elements` as, even if I did some tests it did not work properly as it is difficult to control them because it depends on the path length and size in the canvas. Anyway, it could be controlled with the `sup-path` effect and animate the `complete` parameter
