### PR TITLE
Remove SingleWidgetTarget abstraction

### DIFF
--- a/src/core/Private/document.cpp
+++ b/src/core/Private/document.cpp
@@ -116,7 +116,6 @@ void Document::setCanvasMode(const CanvasMode mode) {
 Canvas *Document::createNewScene(const bool emitCreated) {
     const auto newScene = enve::make_shared<Canvas>(*this);
     fScenes.append(newScene);
-    SWT_addChild(newScene.get());
     if (emitCreated) {
         emit sceneCreated(newScene.get());
     }
@@ -131,7 +130,6 @@ bool Document::removeScene(const qsptr<Canvas>& scene) {
 bool Document::removeScene(const int id) {
     if(id < 0 || id >= fScenes.count()) return false;
     const auto scene = fScenes.takeAt(id);
-    SWT_removeChild(scene.data());
     emit sceneRemoved(scene.data());
     emit sceneRemoved(id);
     return true;
@@ -302,14 +300,4 @@ void Document::clear() {
         removeBookmarkColor(color);
     }
     fColors.clear();
-}
-
-void Document::SWT_setupAbstraction(SWT_Abstraction * const abstraction,
-                                    const UpdateFuncs &updateFuncs,
-                                    const int visiblePartWidgetId) {
-    for(const auto& scene : fScenes) {
-        auto abs = scene->SWT_abstractionForWidget(updateFuncs,
-                                                   visiblePartWidgetId);
-        abstraction->addChildAbstraction(abs->ref<SWT_Abstraction>());
-    }
 }

--- a/src/core/Private/document.h
+++ b/src/core/Private/document.h
@@ -30,7 +30,6 @@
 #include <QDomDocument>
 
 #include "smartPointers/ememory.h"
-#include "singlewidgettarget.h"
 #include "paintsettings.h"
 #include "Paint/brushcontexedwrapper.h"
 #include "actions.h"
@@ -61,7 +60,7 @@ enum class PaintMode {
     move, crop
 };
 
-class CORE_EXPORT Document : public SingleWidgetTarget {
+class CORE_EXPORT Document {
     Q_OBJECT
 public:
     Document(TaskScheduler& taskScheduler);
@@ -169,10 +168,6 @@ public:
                        ZipFileLoader& fileLoader,
                        const QList<Canvas*>& scenes,
                        const RuntimeIdToWriteId& objListIdConv);
-
-    void SWT_setupAbstraction(SWT_Abstraction * const abstraction,
-                              const UpdateFuncs &updateFuncs,
-                              const int visiblePartWidgetId);
 private:
     void readDocumentXEV(const QDomDocument& doc,
                          QList<Canvas*>& scenes);


### PR DESCRIPTION
I hate the SingleWidgetTarget abstraction. It makes the whole tree hard to read.

I made a document explaining the whole architecture, as well as a WIP proposal: https://www.figma.com/design/s9YWnyj8CNh2IEstjJa3fZ/Friction2d-architecture-roadmap?node-id=0-1&t=r02Zf001sWkeEQqE-1

The first step is to untie the `Private/Document` class from `SingleTargetWidget`.