### PR TITLE
Bump to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@
 cmake_minimum_required(VERSION 3.12)
 project(friction.graphics)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+
 option(BUILD_ENGINE "Build Engine" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake")


### PR DESCRIPTION
Bumping the C++ version is useful because while it allows you to make new code more readable, all compatibility is kept with older versions. Ergo, bumping doesn't hurt at all.

I conservatively bumped to C++17, but C++20 should be fine too.

Useful C++ features that aren't in C++11: https://www.geeksforgeeks.org/features-of-c17-with-examples/


**I couldn't find where the standard was set before. So I set it in the root `CMakeLists.txt`. Please tell me where you had it set before @rodlie **