### PR TITLE
UI/UX: add toolbar to viewer

### DIFF
--- a/src/app/GUI/mainwindow.h
+++ b/src/app/GUI/mainwindow.h
@@ -39,7 +39,7 @@
 #include <QComboBox>
 #include <QTimer>
 
-#include "widgets/fontswidget.h"
+
 #include "Private/Tasks/taskscheduler.h"
 #include "Private/document.h"
 #include "Sound/audiohandler.h"
@@ -48,14 +48,18 @@
 #include "renderhandler.h"
 #include "fileshandler.h"
 #include "ekeyfilter.h"
+#include "window.h"
 #include "GUI/RenderWidgets/renderwidget.h"
+
+#include "widgets/fontswidget.h"
+#include "widgets/toolbar.h"
+#include "widgets/transformtoolbar.h"
 #include "widgets/colortoolbar.h"
 #include "widgets/qdoubleslider.h"
 #include "widgets/canvastoolbar.h"
-#include "window.h"
+#include "widgets/viewertoolbar.h"
 #include "widgets/aboutwidget.h"
 #include "widgets/uilayout.h"
-#include "widgets/toolbar.h"
 
 class VideoEncoder;
 class RenderWidget;
@@ -362,6 +366,9 @@ private:
 
     Friction::Ui::ColorToolBar *mColorToolBar;
     Friction::Ui::CanvasToolBar *mCanvasToolBar;
+    Friction::Ui::TransformToolBar *mTransformToolBar;
+    Friction::Ui::ViewerToolBar *mViewerLeftToolBar;
+    Friction::Ui::ViewerToolBar *mViewerRightToolBar;
 
     void setupToolBox();
     void setupToolBoxMain();
@@ -401,6 +408,7 @@ private:
     void askRestoreFillStrokeDefault();
 
     QLabel *mColorPickLabel;
+    QAction *mColorPickLabelAct;
 
     QAction *mToolBarMainAct;
     QAction *mToolBarColorAct;

--- a/src/app/GUI/toolbox.cpp
+++ b/src/app/GUI/toolbox.cpp
@@ -201,7 +201,6 @@ void MainWindow::setupToolBoxMain()
     textModeAct->setShortcut(QKeySequence(AppSupport::getSettings("shortcuts",
                                                                   "textMode",
                                                                   "F7").toString()));
-    //cmdAddAction(textModeAct);
     connect(textModeAct,
             &QAction::triggered,
             this,
@@ -297,7 +296,6 @@ void MainWindow::setupToolBoxMain()
 void MainWindow::setupToolBoxNodes()
 {
     mToolBoxGroupNodes = new QActionGroup(this);
-    mToolBoxGroupNodes->addAction(mToolBoxMain->addSeparator());
 
     // nodeConnect
     mActionConnectPointsAct = new QAction(QIcon::fromTheme("nodeConnect"),
@@ -408,8 +406,8 @@ void MainWindow::setupToolBoxNodes()
         Document::sInstance->actionFinished();
     });
 
-    mToolBoxMain->addActions(mToolBoxGroupNodes->actions());
-    mNodeVisibilityAct = mToolBoxMain->addWidget(mNodeVisibility);
+    mViewerRightToolBar->addActions(mToolBoxGroupNodes->actions());
+    mNodeVisibilityAct = mViewerRightToolBar->addWidget(mNodeVisibility);
 
     setEnableToolBoxNodes(false);
 }
@@ -432,11 +430,8 @@ void MainWindow::setupToolBoxDraw()
     });
 
     mDrawPathMaxError = new QDoubleSlider(1, 200, 1, this, false);
-    mDrawPathMaxError->setSizePolicy(QSizePolicy::MinimumExpanding,
-                                     QSizePolicy::Preferred);
     mDrawPathMaxError->setNumberDecimals(0);
-    mDrawPathMaxError->setMinimumSize({eSizesUI::widget,
-                                       eSizesUI::widget});
+    mDrawPathMaxError->setMinimumWidth(50);
     mDrawPathMaxError->setDisplayedValue(mDocument.fDrawPathMaxError);
     connect(mDrawPathMaxError, &QDoubleSlider::valueEdited,
             this, [this](const qreal value) {
@@ -444,63 +439,35 @@ void MainWindow::setupToolBoxDraw()
     });
 
     mDrawPathSmooth = new QDoubleSlider(1, 200, 1, this, false);
-    mDrawPathSmooth->setSizePolicy(QSizePolicy::MinimumExpanding,
-                                   QSizePolicy::Preferred);
     mDrawPathSmooth->setNumberDecimals(0);
-    mDrawPathSmooth->setMinimumSize({eSizesUI::widget,
-                                     eSizesUI::widget});
+    mDrawPathSmooth->setMinimumWidth(50);
     mDrawPathSmooth->setDisplayedValue(mDocument.fDrawPathSmooth);
     connect(mDrawPathSmooth, &QDoubleSlider::valueEdited,
             this, [this](const qreal value) {
         mDocument.fDrawPathSmooth = qFloor(value);
     });
 
-    eSizesUI::widget.add(mDrawPathMaxError, [this](const int size) {
-        mDrawPathMaxError->setMinimumSize({size, size});
-        mDrawPathSmooth->setMinimumSize({size, size});
-    });
-
-    connect(mToolBoxMain, &QToolBar::orientationChanged,
-            this, [this](Qt::Orientation orientation) {
-        const auto policyH = orientation == Qt::Vertical ?
-                                 QSizePolicy::MinimumExpanding :
-                                 QSizePolicy::Preferred;
-        const auto policyV = orientation == Qt::Vertical ?
-                                 QSizePolicy::Preferred :
-                                 QSizePolicy::MinimumExpanding;
-        mDrawPathMaxError->setSizePolicy(policyH, policyV);
-        mDrawPathSmooth->setSizePolicy(policyH, policyV);
-    });
-
     const auto label1 = new VLabel(QString("%1 ").arg(tr("Max Error")),
                                    this,
-                                   mToolBoxMain->orientation());
+                                   mViewerRightToolBar->orientation());
     const auto label2 = new VLabel(QString("%1 ").arg(tr("Smooth")),
                                    this,
-                                   mToolBoxMain->orientation());
+                                   mViewerRightToolBar->orientation());
 
-    connect(mToolBoxMain, &QToolBar::orientationChanged,
-            this, [label1, label2](Qt::Orientation orientation){
-        label1->setOrientation(orientation);
-        label2->setOrientation(orientation);
-    });
-
-    mToolBoxDrawActSep = mToolBoxMain->addSeparator();
-
-    mToolBoxDrawActIcon1 = mToolBoxMain->addAction(QIcon::fromTheme("drawPath"),
-                                                   QString());
+    mToolBoxDrawActIcon1 = mViewerRightToolBar->addAction(QIcon::fromTheme("drawPath"),
+                                                          QString());
     mToolBoxDrawActIcon1->setDisabled(true);
 
-    mToolBoxDrawActLabel1 = mToolBoxMain->addWidget(label1);
-    mToolBoxDrawActMaxError = mToolBoxMain->addWidget(mDrawPathMaxError);
+    mToolBoxDrawActLabel1 = mViewerRightToolBar->addWidget(label1);
+    mToolBoxDrawActMaxError = mViewerRightToolBar->addWidget(mDrawPathMaxError);
 
-    mToolBoxDrawActIcon2 = mToolBoxMain->addAction(QIcon::fromTheme("drawPath"),
-                                                   QString());
+    mToolBoxDrawActIcon2 = mViewerRightToolBar->addAction(QIcon::fromTheme("drawPath"),
+                                                          QString());
     mToolBoxDrawActIcon2->setDisabled(true);
 
-    mToolBoxDrawActLabel2 = mToolBoxMain->addWidget(label2);
-    mToolBoxDrawActSmooth = mToolBoxMain->addWidget(mDrawPathSmooth);
-    mToolBoxMain->addAction(mDrawPathAuto);
+    mToolBoxDrawActLabel2 = mViewerRightToolBar->addWidget(label2);
+    mToolBoxDrawActSmooth = mViewerRightToolBar->addWidget(mDrawPathSmooth);
+    mViewerRightToolBar->addAction(mDrawPathAuto);
 
     setEnableToolBoxDraw(false);
 }

--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -601,13 +601,14 @@ QCheckBox:disabled {
     color: %13;
 }
 
-QToolBar#DarkToolBar {
+QToolBar#DarkToolBar,
+Friction--Ui--TransformToolBar {
     background-color: %5;
 }
 
 QToolBar#ColorToolBar QToolButton:hover,
-QToolBar#CanvasToolBar QToolButton:hover
-{
+QToolBar#CanvasToolBar QToolButton:hover,
+Friction--Ui--TransformToolBar QToolButton:hover {
     background-color: transparent;
     border-color: transparent;
 }
@@ -632,6 +633,18 @@ Friction--Ui--ToolBar::separator:vertical {
 
 Friction--Ui--ToolBar::separator:horizontal {
     width: 1px;
+}
+
+Friction--Ui--TransformToolBar::separator {
+    background-color: transparent;
+}
+
+Friction--Ui--TransformToolBar::separator:horizontal {
+    width: 2px;
+}
+
+Friction--Ui--TransformToolBar QComboBox {
+    padding: .1em;
 }
 
 ExpressionEditor {

--- a/src/core/Boxes/circle.cpp
+++ b/src/core/Boxes/circle.cpp
@@ -138,6 +138,21 @@ qreal Circle::getCurrentYRadius() {
     return mVerticalRadiusAnimator->getEffectiveYValue();
 }
 
+QPointFAnimator *Circle::getCenterAnimator()
+{
+    return mCenterAnimator.get();
+}
+
+QPointFAnimator *Circle::getHRadiusAnimator()
+{
+    return mHorizontalRadiusAnimator.get();
+}
+
+QPointFAnimator *Circle::getVRadiusAnimator()
+{
+    return mVerticalRadiusAnimator.get();
+}
+
 void Circle::getMotionBlurProperties(QList<Property*> &list) const {
     PathBox::getMotionBlurProperties(list);
     list.append(mHorizontalRadiusAnimator.get());

--- a/src/core/Boxes/circle.h
+++ b/src/core/Boxes/circle.h
@@ -66,6 +66,11 @@ public:
 
     qreal getCurrentXRadius();
     qreal getCurrentYRadius();
+
+    QPointFAnimator* getCenterAnimator();
+    QPointFAnimator* getHRadiusAnimator();
+    QPointFAnimator* getVRadiusAnimator();
+
 protected:
     void getMotionBlurProperties(QList<Property*> &list) const;
 private:

--- a/src/core/Boxes/rectangle.cpp
+++ b/src/core/Boxes/rectangle.cpp
@@ -104,6 +104,21 @@ void RectangleBox::setXRadius(const qreal radiusX) {
     mRadiusAnimator->getXAnimator()->setCurrentBaseValue(radiusX);
 }
 
+QPointFAnimator *RectangleBox::getTopLeftAnimator()
+{
+    return mTopLeftAnimator.get();
+}
+
+QPointFAnimator *RectangleBox::getBottomRightAnimator()
+{
+    return mBottomRightAnimator.get();
+}
+
+QPointFAnimator *RectangleBox::getRadiusAnimator()
+{
+    return mRadiusAnimator.get();
+}
+
 void RectangleBox::moveSizePointByAbs(const QPointF &absTrans) {
     mBottomRightPoint->moveByAbs(absTrans);
 }

--- a/src/core/Boxes/rectangle.h
+++ b/src/core/Boxes/rectangle.h
@@ -47,6 +47,11 @@ public:
     void setBottomRightPos(const QPointF &pos);
     void setYRadius(const qreal radiusY);
     void setXRadius(const qreal radiusX);
+
+    QPointFAnimator* getTopLeftAnimator();
+    QPointFAnimator* getBottomRightAnimator();
+    QPointFAnimator* getRadiusAnimator();
+
 private:
     qsptr<QPointFAnimator> mTopLeftAnimator;
     qsptr<QPointFAnimator> mBottomRightAnimator;

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -852,6 +852,7 @@ void Canvas::setCanvasMode(const CanvasMode mode)
     clearLastPressedPoint();
     updatePivot();
     //updatePaintBox();
+    emit canvasModeSet(mode);
 }
 
 /*void Canvas::updatePaintBox()
@@ -1062,6 +1063,11 @@ void Canvas::clearSelectionAction()
         clearPointsSelection();
         clearBoxesSelection();
     }
+}
+
+void Canvas::finishedAction()
+{
+    mDocument.actionFinished();
 }
 
 void Canvas::clearParentForSelected()

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -148,6 +148,7 @@ public:
                           const bool startTrans);
 
     QPointF getSelectedBoxesAbsPivotPos();
+    int getSelectedBoxesCount();
     bool isBoxSelectionEmpty() const;
 
     void ungroupSelectedBoxes();
@@ -450,6 +451,7 @@ signals:
     void currentPickedColor(const QColor &color);
     void currentHoverColor(const QColor &color);
     void markersChanged();
+    void canvasModeSet(const CanvasMode &mode);
 
 public:
     void makePointCtrlsSymmetric();
@@ -561,6 +563,7 @@ public:
     void duplicateAction();
     void selectAllAction();
     void clearSelectionAction();
+    void finishedAction();
     void rotateSelectedBoxesStartAndFinish(const qreal rotBy,
                                            bool inc = true);
     void scaleSelectedBoxesStartAndFinish(const qreal scaleBy);

--- a/src/core/canvasselectedboxesactions.cpp
+++ b/src/core/canvasselectedboxesactions.cpp
@@ -418,6 +418,11 @@ QPointF Canvas::getSelectedBoxesAbsPivotPos() {
     return posSum/count;
 }
 
+int Canvas::getSelectedBoxesCount()
+{
+    return mSelectedBoxes.count();
+}
+
 bool Canvas::isBoxSelectionEmpty() const {
     return mSelectedBoxes.isEmpty();
 }

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -103,8 +103,10 @@ set(
     widgets/scenechooser.cpp
     widgets/settingswidget.cpp
     widgets/toolbar.cpp
+    widgets/transformtoolbar.cpp
     widgets/twocolumnlayout.cpp
     widgets/uilayout.cpp
+    widgets/viewertoolbar.cpp
     widgets/welcomedialog.cpp
     widgets/widgetstack.cpp
     widgets/widgetwrappernode.cpp
@@ -176,9 +178,11 @@ set(
     widgets/settingswidget.h
     widgets/toolbar.h
     widgets/toolbutton.h
+    widgets/transformtoolbar.h
     widgets/twocolumnlayout.h
     widgets/uilayout.h
     widgets/vlabel.h
+    widgets/viewertoolbar.h
     widgets/welcomedialog.h
     widgets/widgetstack.h
     widgets/widgetwrappernode.h

--- a/src/ui/widgets/toolbar.cpp
+++ b/src/ui/widgets/toolbar.cpp
@@ -68,6 +68,10 @@ void ToolBar::setup()
     setStyleSheet(QString("font-size: %1pt;").arg(font().pointSize()));
 #endif
 
+    eSizesUI::widget.add(this, [this](const int size) {
+        this->setIconSize({size, size});
+    });
+
     if (objectName().isEmpty()) {
         setObjectName(windowTitle().replace(" ", "").simplified());
     }

--- a/src/ui/widgets/transformtoolbar.cpp
+++ b/src/ui/widgets/transformtoolbar.cpp
@@ -1,0 +1,205 @@
+/*
+#
+# Friction - https://friction.graphics
+#
+# Copyright (c) Ole-André Rodlie and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See 'README.md' for more information.
+#
+*/
+
+#include "transformtoolbar.h"
+#include "Animators/qpointfanimator.h"
+#include "Animators/transformanimator.h"
+#include "Private/document.h"
+#include "Boxes/circle.h"
+#include "Boxes/rectangle.h"
+
+using namespace Friction::Ui;
+
+TransformToolBar::TransformToolBar(QWidget *parent)
+    : ToolBar("TransformToolBar", parent, true)
+    , mTransformX(nullptr)
+    , mTransformY(nullptr)
+    , mTransformR(nullptr)
+    , mTransformSX(nullptr)
+    , mTransformSY(nullptr)
+    , mTransformRX(nullptr)
+    , mTransformRY(nullptr)
+    , mTransformMove(nullptr)
+    , mTransformRotate(nullptr)
+    , mTransformScale(nullptr)
+    , mTransformRadius(nullptr)
+{
+    setToolButtonStyle(Qt::ToolButtonIconOnly);
+    setContextMenuPolicy(Qt::NoContextMenu);
+    setAllowedAreas(Qt::TopToolBarArea | Qt::BottomToolBarArea);
+    setWindowTitle(tr("Transform Toolbar"));
+
+    setupWidgets();
+}
+
+void TransformToolBar::setCurrentCanvas(Canvas * const target)
+{
+    mCanvas.assign(target);
+    if (target) {
+        mCanvas << connect(mCanvas, &Canvas::currentBoxChanged,
+                           this, &TransformToolBar::setCurrentBox);
+        mCanvas << connect(mCanvas, &Canvas::canvasModeSet,
+                           this, &TransformToolBar::setCanvasMode);
+    }
+    setCurrentBox(target ? target->getCurrentBox() : nullptr);
+}
+
+void TransformToolBar::setCurrentBox(BoundingBox * const target)
+{
+    setTransform(target);
+}
+
+void TransformToolBar::setCanvasMode(const CanvasMode &mode)
+{
+    const bool hasRadius = mTransformRX->hasTarget() && mTransformRY->hasTarget();
+    const bool showRadius = mode == CanvasMode::boxTransform ||
+                            mode == CanvasMode::circleCreate ||
+                            mode == CanvasMode::rectCreate;
+    mTransformRadius->setVisible(hasRadius && showRadius);
+}
+
+void TransformToolBar::setTransform(BoundingBox * const target)
+{
+    const bool multiple = target ? mCanvas->getSelectedBoxesCount() > 1 : false;
+    // TODO: add support for multiple boxes
+
+    if (!target || multiple) {
+        clearTransform();
+        return;
+    }
+
+    const auto animator = target->getTransformAnimator();
+    if (!animator) {
+        clearTransform();
+        return;
+    }
+
+    const auto pos = animator->getPosAnimator();
+    mTransformX->setTarget(pos ? pos->getXAnimator() : nullptr);
+    mTransformY->setTarget(pos ? pos->getYAnimator() : nullptr);
+
+    mTransformMove->setEnabled(pos);
+
+    const auto rot = animator->getRotAnimator();
+    mTransformR->setTarget(rot);
+
+    mTransformRotate->setEnabled(rot);
+
+    const auto scale = animator->getScaleAnimator();
+    mTransformSX->setTarget(scale ? scale->getXAnimator() : nullptr);
+    mTransformSY->setTarget(scale ? scale->getYAnimator() : nullptr);
+
+    mTransformScale->setEnabled(scale);
+
+    const auto circle = enve_cast<Circle*>(target);
+    const auto rectangle = enve_cast<RectangleBox*>(target);
+
+    mTransformRX->setTarget(circle ?
+                                circle->getHRadiusAnimator()->getXAnimator() :
+                                (rectangle ? rectangle->getRadiusAnimator()->getXAnimator() : nullptr));
+    mTransformRY->setTarget(circle ?
+                                circle->getVRadiusAnimator()->getYAnimator() :
+                                (rectangle ? rectangle->getRadiusAnimator()->getYAnimator() : nullptr));
+
+    const bool hasRadius = (circle || rectangle);
+
+    mTransformRadius->setEnabled(hasRadius);
+    mTransformRadius->setVisible(hasRadius);
+}
+
+void TransformToolBar::clearTransform()
+{
+    mTransformX->setTarget(nullptr);
+    mTransformY->setTarget(nullptr);
+    mTransformR->setTarget(nullptr);
+    mTransformSX->setTarget(nullptr);
+    mTransformSY->setTarget(nullptr);
+    mTransformRX->setTarget(nullptr);
+    mTransformRY->setTarget(nullptr);
+
+    mTransformMove->setEnabled(false);
+    mTransformRotate->setEnabled(false);
+    mTransformScale->setEnabled(false);
+    mTransformRadius->setEnabled(false);
+
+    mTransformRadius->setVisible(false);
+}
+
+void TransformToolBar::setupWidgets()
+{
+    setupTransform();
+}
+
+void TransformToolBar::setupTransform()
+{
+    mTransformMove = new QActionGroup(this);
+    mTransformRotate = new QActionGroup(this);
+    mTransformScale = new QActionGroup(this);
+    mTransformRadius = new QActionGroup(this);
+
+    mTransformX = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformY = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformR = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformSX = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformSY = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformRX = new QrealAnimatorValueSlider(nullptr, this);
+    mTransformRY = new QrealAnimatorValueSlider(nullptr, this);
+
+    mTransformMove->addAction(addAction(QIcon::fromTheme("boxTransform"),
+                                        tr("Move")));
+    mTransformMove->addAction(addWidget(mTransformX));
+    mTransformMove->addAction(addSeparator());
+    mTransformMove->addAction(addWidget(mTransformY));
+
+    mTransformRotate->addAction(addAction(QIcon::fromTheme("loop3"),
+                                          tr("Rotate")));
+    mTransformRotate->addAction(addWidget(mTransformR));
+
+    mTransformScale->addAction(addAction(QIcon::fromTheme("fullscreen"),
+                                         tr("Scale")));
+    mTransformScale->addAction(addWidget(mTransformSX));
+    mTransformScale->addAction(addSeparator());
+    mTransformScale->addAction(addWidget(mTransformSY));
+
+    mTransformRadius->addAction(addAction(QIcon::fromTheme("circleCreate"),
+                                          tr("Radius")));
+    mTransformRadius->addAction(addWidget(mTransformRX));
+    mTransformRadius->addAction(addSeparator());
+    mTransformRadius->addAction(addWidget(mTransformRY));
+
+    clearTransform();
+
+    mTransformX->setValueRange(0, 1);
+    mTransformX->setDisplayedValue(0);
+    mTransformY->setValueRange(0, 1);
+    mTransformY->setDisplayedValue(0);
+    mTransformR->setValueRange(0, 1);
+    mTransformR->setDisplayedValue(0);
+    mTransformSX->setValueRange(0, 1);
+    mTransformSX->setDisplayedValue(0);
+    mTransformSY->setValueRange(0, 1);
+    mTransformSY->setDisplayedValue(0);
+    mTransformRX->setValueRange(0, 1);
+    mTransformRX->setDisplayedValue(0);
+    mTransformRY->setValueRange(0, 1);
+    mTransformRY->setDisplayedValue(0);
+}

--- a/src/ui/widgets/transformtoolbar.h
+++ b/src/ui/widgets/transformtoolbar.h
@@ -1,0 +1,72 @@
+/*
+#
+# Friction - https://friction.graphics
+#
+# Copyright (c) Ole-André Rodlie and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See 'README.md' for more information.
+#
+*/
+
+#ifndef FRICTION_TRANSFORM_TOOLBAR_H
+#define FRICTION_TRANSFORM_TOOLBAR_H
+
+#include "ui_global.h"
+
+#include "widgets/toolbar.h"
+#include "widgets/qrealanimatorvalueslider.h"
+#include "canvas.h"
+
+#include <QActionGroup>
+
+namespace Friction
+{
+    namespace Ui
+    {
+        class UI_EXPORT TransformToolBar : public ToolBar
+        {
+            Q_OBJECT
+
+        public:
+            explicit TransformToolBar(QWidget *parent = nullptr);
+            void setCurrentCanvas(Canvas * const target);
+            void setCurrentBox(BoundingBox * const target);
+            void setCanvasMode(const CanvasMode &mode);
+
+        private:
+            void setTransform(BoundingBox * const target);
+            void clearTransform();
+            void setupWidgets();
+            void setupTransform();
+
+            ConnContextQPtr<Canvas> mCanvas;
+
+            QrealAnimatorValueSlider *mTransformX;
+            QrealAnimatorValueSlider *mTransformY;
+            QrealAnimatorValueSlider *mTransformR;
+            QrealAnimatorValueSlider *mTransformSX;
+            QrealAnimatorValueSlider *mTransformSY;
+            QrealAnimatorValueSlider *mTransformRX;
+            QrealAnimatorValueSlider *mTransformRY;
+
+            QActionGroup *mTransformMove;
+            QActionGroup *mTransformRotate;
+            QActionGroup *mTransformScale;
+            QActionGroup *mTransformRadius;
+        };
+    }
+}
+
+#endif // FRICTION_TRANSFORM_TOOLBAR_H

--- a/src/ui/widgets/viewertoolbar.cpp
+++ b/src/ui/widgets/viewertoolbar.cpp
@@ -1,0 +1,37 @@
+/*
+#
+# Friction - https://friction.graphics
+#
+# Copyright (c) Ole-André Rodlie and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See 'README.md' for more information.
+#
+*/
+
+#include "viewertoolbar.h"
+#include "Private/document.h"
+
+using namespace Friction::Ui;
+
+ViewerToolBar::ViewerToolBar(const QString &name,
+                             const QString &title,
+                             QWidget *parent)
+    : ToolBar(name, parent, true)
+{
+    setToolButtonStyle(Qt::ToolButtonIconOnly);
+    setContextMenuPolicy(Qt::NoContextMenu);
+    setAllowedAreas(Qt::TopToolBarArea | Qt::BottomToolBarArea);
+    setWindowTitle(title);
+}

--- a/src/ui/widgets/viewertoolbar.h
+++ b/src/ui/widgets/viewertoolbar.h
@@ -1,0 +1,44 @@
+/*
+#
+# Friction - https://friction.graphics
+#
+# Copyright (c) Ole-André Rodlie and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# See 'README.md' for more information.
+#
+*/
+
+#ifndef FRICTION_VIEWER_TOOLBAR_H
+#define FRICTION_VIEWER_TOOLBAR_H
+
+#include "ui_global.h"
+
+#include "widgets/toolbar.h"
+
+namespace Friction
+{
+    namespace Ui
+    {
+        class UI_EXPORT ViewerToolBar : public ToolBar
+        {
+        public:
+            explicit ViewerToolBar(const QString &name,
+                                   const QString &title,
+                                   QWidget *parent = nullptr);
+        };
+    }
+}
+
+#endif // FRICTION_VIEWER_TOOLBAR_H


### PR DESCRIPTION
Introduces a new toolbar under the viewer.

- "Extra" tools based on mode has been moved to new toolbar
- Color picker status has moved to new toolbar
- Added option for "common" actions in new toolbar, currently has undo/redo
- Added transform toolbar for easy access to common transform actions

More can be added or changed, but if we want this in v1.0 then we have limited time, so I would say it's good enough (unless it breaks something of course), we can always improve it in v1.1.

<img width="1687" alt="Screenshot 2025-05-12 at 09 52 10" src="https://github.com/user-attachments/assets/0a100d1a-d91f-421e-b68d-538f2a1d5f3c" />
<img width="1687" alt="Screenshot 2025-05-12 at 09 53 24" src="https://github.com/user-attachments/assets/1acdb3b1-10ee-43be-9d5f-555e75ef514b" />
<img width="1687" alt="Screenshot 2025-05-12 at 09 53 40" src="https://github.com/user-attachments/assets/71870acf-ed06-442e-a96f-9f27ef42d211" />
<img width="1687" alt="Screenshot 2025-05-12 at 09 53 57" src="https://github.com/user-attachments/assets/7de98d5c-0483-44b0-95e6-e39afdb72467" />
<img width="1687" alt="Screenshot 2025-05-12 at 09 54 18" src="https://github.com/user-attachments/assets/e29d2d32-6788-4b69-9611-97d47116838c" />


Related to issue #507 