### PR TITLE
Value Slider: support TAB to sibling

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -1675,6 +1675,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *e)
         const auto keyEvent = static_cast<QKeyEvent*>(e);
         const int key = keyEvent->key();
         if (key == Qt::Key_Tab) {
+            if (enve_cast<QLineEdit*>(focusWidget)) { return true; }
             KeyFocusTarget::KFT_sTab();
             return true;
         }

--- a/src/core/Animators/qrealanimator.h
+++ b/src/core/Animators/qrealanimator.h
@@ -234,6 +234,7 @@ signals:
     void expressionChanged();
     void effectiveValueChanged(qreal);
     void baseValueChanged(qreal);
+    void requestWidgetFocus();
 };
 
 class CORE_EXPORT QrealAction {

--- a/src/ui/widgets/qdoubleslider.cpp
+++ b/src/ui/widgets/qdoubleslider.cpp
@@ -59,6 +59,10 @@ void SliderEdit::keyPressEvent(QKeyEvent* e) {
     case Qt::Key_Enter:
         clearFocus();
         break;
+    case Qt::Key_Tab:
+        clearFocus();
+        emit tabPressed();
+        break;
     default: QLineEdit::keyPressEvent(e);
     }
 }
@@ -117,6 +121,8 @@ QDoubleSlider::QDoubleSlider(const qreal minVal, const qreal maxVal,
         unsetCursor();
         update();
     });
+    connect(mLineEdit, &SliderEdit::tabPressed,
+            this, [this]() { emit tabPressed(); });
     connect(mLineEdit, &SliderEdit::valueSet,
             this, [this](const qreal value) {
         const qreal clampedValue = clamped(value);
@@ -169,6 +175,15 @@ void QDoubleSlider::setNumberDecimals(const int decimals) {
     mDecimals = decimals;
     if (mAutoAdjustWidth) { fitWidthToContent(); }
     updateValueString();
+}
+
+void QDoubleSlider::setLineEditFocus()
+{
+    updateLineEditFromValue();
+    mCanceled = false;
+    mLineEdit->show();
+    mLineEdit->setFocus();
+    mLineEdit->selectAll();
 }
 
 void QDoubleSlider::updateLineEditFromValue() {

--- a/src/ui/widgets/qdoubleslider.h
+++ b/src/ui/widgets/qdoubleslider.h
@@ -43,6 +43,7 @@ public:
 signals:
     void valueSet(const qreal value);
     void hoverChanged();
+    void tabPressed();
 protected:
     void mousePressEvent(QMouseEvent* e) override;
     void keyPressEvent(QKeyEvent *e) override;
@@ -75,6 +76,7 @@ public:
     void setNameVisible(const bool nameVisible);
     void setName(const QString& name);
     void setNumberDecimals(const int decimals);
+    void setLineEditFocus();
 
     void fitWidthToContent();
     QString getValueString();
@@ -131,6 +133,7 @@ signals:
     void valueEdited(qreal);
     void editingFinished(qreal);
     void editingCanceled();
+    void tabPressed();
 protected:
     QString valueToText(const qreal value) const;
     qreal getDValueForMouseMove(const int mouseX) const;

--- a/src/ui/widgets/qrealanimatorvalueslider.h
+++ b/src/ui/widgets/qrealanimatorvalueslider.h
@@ -83,9 +83,11 @@ protected:
     void keyReleaseEvent(QKeyEvent *e);
     bool eventFilter(QObject *obj,
                      QEvent *event);
+    void handleTabPressed();
 
 private:
     QrealAnimator *getTransformTargetSibling();
+    QrealAnimator *getTargetSibling();
     void targetHasExpressionChanged();
 
     QMetaObject::Connection mExprConn;


### PR DESCRIPTION
Support TAB to focus from/to X/Y value sliders.

https://github.com/user-attachments/assets/4aff6665-5540-49cc-b449-412568c17bf6

Only tested on macOS.