### PR TITLE
Add a spacer for every parameter group (before icon)

### DIFF
--- a/src/app/friction.qss
+++ b/src/app/friction.qss
@@ -290,6 +290,11 @@ QToolButton::menu-button {
     background-color: transparent;
 }
 
+QToolBar#ToolControls QWidget[isSpacer="true"] {
+    min-width: %10px;
+    max-width: %10px;
+}
+
 QPushButton::menu-indicator,
 QToolButton#ToolButton::menu-indicator,
 QToolButton#FlatButton::menu-indicator { width: 0px; }

--- a/src/ui/widgets/toolbox.cpp
+++ b/src/ui/widgets/toolbox.cpp
@@ -312,6 +312,10 @@ void ToolBox::setupNodesAction(const QIcon &icon,
 
 void ToolBox::setupNodesActions()
 {
+    auto* spacerNodes = new QWidget(mControls);
+    spacerNodes->setProperty("isSpacer", true);
+    QAction* spacerAct = mControls->addWidget(spacerNodes);
+    mGroupNodes->addAction(spacerAct);
     mControls->addAction(mGroupNodes->addAction(QIcon::fromTheme("pointTransform"),
                                                 tr("Nodes")));
 

--- a/src/ui/widgets/toolcontrols.cpp
+++ b/src/ui/widgets/toolcontrols.cpp
@@ -215,38 +215,59 @@ void ToolControls::setupTransform()
     mTransformPY = new QrealAnimatorValueSlider(nullptr, this);
     mTransformOX = new QrealAnimatorValueSlider(nullptr, this);
 
+    auto* spacerMove = new QWidget(this);
+    spacerMove->setProperty("isSpacer", true);
+    mTransformMove->addAction(addWidget(spacerMove));
     mTransformMove->addAction(addAction(QIcon::fromTheme("boxTransform"),
                                         tr("Move")));
     mTransformMove->addAction(addWidget(mTransformX));
     mTransformMove->addAction(addSeparator());
     mTransformMove->addAction(addWidget(mTransformY));
 
+    auto* spacerRotate = new QWidget(this);
+    spacerRotate->setProperty("isSpacer", true);
+    mTransformRotate->addAction(addWidget(spacerRotate));
     mTransformRotate->addAction(addAction(QIcon::fromTheme("loop3"),
                                           tr("Rotate")));
     mTransformRotate->addAction(addWidget(mTransformR));
 
+    auto* spacerScale = new QWidget(this);
+    spacerScale->setProperty("isSpacer", true);
+    mTransformScale->addAction(addWidget(spacerScale));
     mTransformScale->addAction(addAction(QIcon::fromTheme("fullscreen"),
                                          tr("Scale")));
     mTransformScale->addAction(addWidget(mTransformSX));
     mTransformScale->addAction(addSeparator());
     mTransformScale->addAction(addWidget(mTransformSY));
 
+    auto* spacerPivot = new QWidget(this);
+    spacerPivot->setProperty("isSpacer", true);
+    mTransformPivot->addAction(addWidget(spacerPivot));
     mTransformPivot->addAction(addAction(QIcon::fromTheme("pivot"),
                                          tr("Pivot")));
     mTransformPivot->addAction(addWidget(mTransformPX));
     mTransformPivot->addAction(addSeparator());
     mTransformPivot->addAction(addWidget(mTransformPY));
 
+    auto* spacerOpacity = new QWidget(this);
+    spacerOpacity->setProperty("isSpacer", true);
+    mTransformOpacity->addAction(addWidget(spacerOpacity));
     mTransformOpacity->addAction(addAction(QIcon::fromTheme("alpha"),
                                            tr("Opacity")));
     mTransformOpacity->addAction(addWidget(mTransformOX));
 
+    auto* spacerBottomRight = new QWidget(this);
+    spacerBottomRight->setProperty("isSpacer", true);
+    mTransformBottomRight->addAction(addWidget(spacerBottomRight));
     mTransformBottomRight->addAction(addAction(QIcon::fromTheme("rectCreate"),
                                               tr("Rectangle")));
     mTransformBottomRight->addAction(addWidget(mTransformBX));
     mTransformBottomRight->addAction(addSeparator());
     mTransformBottomRight->addAction(addWidget(mTransformBY));
 
+    auto* spacerRadius = new QWidget(this);
+    spacerRadius->setProperty("isSpacer", true);
+    mTransformRadius->addAction(addWidget(spacerRadius));
     mTransformRadius->addAction(addAction(QIcon::fromTheme("circleCreate"),
                                           tr("Radius")));
     mTransformRadius->addAction(addWidget(mTransformRX));


### PR DESCRIPTION
This way it feels now more natural:
<img width="1355" height="656" alt="spacers" src="https://github.com/user-attachments/assets/e6b13ade-a98e-4491-9d3e-1ba29967e80b" />

I used "half of an icon" width, I feel like it would go better "a quarter of an icon" but the variable is not created and I didn't want to do it at this step... let me know if you like it and I go further.

Cheers