### PR TITLE
SVG export: ensure rx and ry values are always positive at export

### DIFF
--- a/src/core/Boxes/circle.cpp
+++ b/src/core/Boxes/circle.cpp
@@ -187,7 +187,17 @@ void Circle::saveSVG(SvgExporter& exp, DomEleTask* const task) const {
     cX->saveQrealSVG(exp, ele, task->visRange(), "cx");
     cY->saveQrealSVG(exp, ele, task->visRange(), "cy");
     rX->saveQrealSVG(exp, ele, task->visRange(), "rx");
+    {
+        bool ok;
+        double v = ele.attribute("rx").toDouble(&ok);
+        if (ok) ele.setAttribute("rx", QString::number(qAbs(v)));
+    }
     rY->saveQrealSVG(exp, ele, task->visRange(), "ry");
+    {
+        bool ok;
+        double v = ele.attribute("ry").toDouble(&ok);
+        if (ok) ele.setAttribute("ry", QString::number(qAbs(v)));
+    }
 
     savePathBoxSVG(exp, ele, task->visRange());
 }


### PR DESCRIPTION
This PR fixes https://github.com/friction2d/friction/issues/553

Depending on how circles are created within Friction, `horizontal radius` and `vertical radius` may take negative values.
When exporting those values to SVG and stored on `rx` and `ry` of an ellipse, negative values are not compliant and depending on your renderer it might turn into transparent shapes (the ellipse is there but not correctly drawn).

This PR ensures the exported values are always the absolute values.

<img width="848" height="476" alt="circles" src="https://github.com/user-attachments/assets/91f3e93f-afbf-439a-b90f-b8007272c73a" />

## Test project
[circles.friction.zip](https://github.com/user-attachments/files/21667841/circles.friction.zip)

## Comparison
**Friction v1.0 RC2**
![circles_rc2](https://github.com/user-attachments/assets/d5859ca0-bf44-4611-bf3d-e6f869274b42)

**Friction v1.0 RC2 with this fix**    
![circles_rc2_fixed](https://github.com/user-attachments/assets/64cc2360-b26d-4d9c-b64b-d62f3de145f1)

I hope it doesn't break anything else...
Cheers

