### PR TITLE
UX: show rectangle 'TopLeft' prop in toolbar

### DIFF
--- a/src/ui/widgets/toolcontrols.h
+++ b/src/ui/widgets/toolcontrols.h
@@ -62,6 +62,8 @@ namespace Friction
             QrealAnimatorValueSlider *mTransformSY;
             QrealAnimatorValueSlider *mTransformRX;
             QrealAnimatorValueSlider *mTransformRY;
+            QrealAnimatorValueSlider *mTransformTX;
+            QrealAnimatorValueSlider *mTransformTY;
             QrealAnimatorValueSlider *mTransformBX;
             QrealAnimatorValueSlider *mTransformBY;
             QrealAnimatorValueSlider *mTransformPX;
@@ -72,6 +74,8 @@ namespace Friction
             QActionGroup *mTransformRotate;
             QActionGroup *mTransformScale;
             QActionGroup *mTransformRadius;
+            QActionGroup *mTransformRectangle;
+            QActionGroup *mTransformTopLeft;
             QActionGroup *mTransformBottomRight;
             QActionGroup *mTransformPivot;
             QActionGroup *mTransformOpacity;


### PR DESCRIPTION
if mode is 'point' or 'rectangle'.

We avoid 'box' mode since we have enough there already(?).

<img width="1136" height="610" alt="Screenshot from 2025-08-12 21-24-53" src="https://github.com/user-attachments/assets/5c8b768b-94d9-435a-9a55-3cb1bc97863b" />
<img width="1298" height="610" alt="Screenshot from 2025-08-12 21-25-14" src="https://github.com/user-attachments/assets/1d630c4c-8a91-45b0-a798-5dd21b62f575" />
<img width="1298" height="610" alt="Screenshot from 2025-08-12 21-27-52" src="https://github.com/user-attachments/assets/bff8ae91-5d7a-4528-bc13-df47cd953c05" />
