### PR TITLE
Fix duplicated color and brushes bookmarks at new or opened document

### DIFF
--- a/src/core/Private/document.cpp
+++ b/src/core/Private/document.cpp
@@ -296,11 +296,13 @@ void Document::clear() {
     const int nScenes = fScenes.count();
     for(int i = 0; i < nScenes; i++) removeScene(0);
     replaceClipboard(nullptr);
-    for(const auto brush : fBrushes) {
+    const auto iBrushes = fBrushes;
+    for (const auto brush : iBrushes) {
         removeBookmarkBrush(brush);
     }
     fBrushes.clear();
-    for(const auto& color : fColors) {
+    const auto iColors = fColors;
+    for (const auto& color : iColors) {
         removeBookmarkColor(color);
     }
     fColors.clear();


### PR DESCRIPTION
When we introduced unbookmark color fix, when creating a new document or when reopening a document with some color bookmarks, they were loaded into the color panel duplicated...

This fixes that behavior