### PR TITLE
Force constant FPS for rendered videos v2

### DIFF
--- a/src/core/videoencoder.h
+++ b/src/core/videoencoder.h
@@ -168,6 +168,8 @@ typedef struct CORE_EXPORT OutputStream {
     AVFrame *fSrcFrame = nullptr;
     struct SwsContext *fSwsCtx = nullptr;
     struct SwrContext *fSwrCtx = nullptr;
+    // Cached per-frame duration in stream time_base ticks
+    int64_t fFrameDuration = 0;
 } OutputStream;
 
 class CORE_EXPORT VideoEncoderEmitter : public QObject {


### PR DESCRIPTION
My second take on trying to fix CFPS (and other video parameters) to all  formats MP4, MOV, WebM, image sequences, ...

_(it started as a discussion https://github.com/orgs/friction2d/discussions/491 and later it came the first PR https://github.com/friction2d/friction/pull/493)_

Once again it's not my work but ChatGPT-5 Codex with my polishing and lots of trial and errors... I don't really control what's in the final code as I'm not familiar with video rendering and stuff but this time it looks to work even with `ffmpeg 4.2`.

Please, have a look at it as ffprobe and kdenlive "aprobe" the rendered videos and everything looks to work properly (better and before indeed).

I'm also pasting an explanation of what the AI did, I hope it helps:

> All the fixes revolve around giving every format the exact same, consistent time-base information and letting libavformat derive the totals itself. In the final version:
> 
> - We cache a single “frame tick” once. OutputStream::fFrameDuration is set either immediately after avformat_write_header (using RenderSettings::fTimeBase) or on the first packet if the muxer reports a different tick. That value stays constant for the whole stream.
> - Every video packet—normal encode path and encoder flush—gets its timestamps rescaled into AVStream::time_base, and then we overwrite pkt.duration with that cached tick. This keeps MP4, MOV and WebM perfectly CFR at the packet level.
> - We stopped forcing mVideoStream.fStream->duration at shutdown. The QuickTime/ProRes muxer now computes the container duration from the consistent timestamps it received, which is why ffprobe reports ~3.333 s instead of 7.58 s.
> - We still update avg_frame_rate / r_frame_rate from the render FPS so downstream tools see the intended cadence.
> 
> With those pieces in place, MP4, WebM, and MOV all share the same per-frame timing, the muxer no longer gets conflicting duration numbers, and ffprobe reports the correct runtime for all three formats.