### PR TITLE
Remove nodes buttons

### DIFF
--- a/src/core/actions.cpp
+++ b/src/core/actions.cpp
@@ -520,6 +520,14 @@ void Actions::subdivideSegments() const
     afterAction();
 }
 
+void Actions::removePointsApprox() const
+{
+    qDebug() << "removePointsApprox";
+    if (!mActiveScene) { return; }
+    mActiveScene->removeSelectedPointsApprox();
+    afterAction();
+}
+
 void Actions::makePointCtrlsSymmetric() const
 {
     qDebug() << "makePointCtrlsSymmetric";

--- a/src/core/actions.h
+++ b/src/core/actions.h
@@ -60,6 +60,7 @@ public:
     void disconnectPointsSlot() const;
     void mergePointsSlot() const;
     void subdivideSegments() const;
+    void removePointsApprox() const;
 
     void makePointCtrlsSymmetric() const;
     void makePointCtrlsSmooth() const;

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -210,6 +210,7 @@ public:
     void setSelectedFontSize(const qreal size);
     void setSelectedFontText(const QString &text);
     void removeSelectedPointsAndClearList();
+    void removeSelectedPointsApprox();
     void removeSelectedBoxesAndClearList();
 
     BoundingBox* getCurrentBox() const { return mCurrentBox; }

--- a/src/core/canvasselectedpointsactions.cpp
+++ b/src/core/canvasselectedpointsactions.cpp
@@ -264,6 +264,40 @@ void Canvas::removeSelectedPointsAndClearList()
     schedulePivotUpdate();
 }
 
+void Canvas::removeSelectedPointsApprox()
+{
+    if (mPressedPoint && mPressedPoint->isCtrlPoint()) {
+        mPressedPoint->finishTransform();
+        removePointFromSelection(mPressedPoint);
+        if (auto *smartPoint = dynamic_cast<SmartNodePoint*>(mPressedPoint.data())) {
+            smartPoint->actionRemove(true);
+        } else {
+            mPressedPoint->remove();
+        }
+        schedulePivotUpdate();
+        return;
+    }
+
+    const auto selected = mSelectedPoints_d;
+    if (selected.count() < 1) {
+        removeSelectedBoxesAndClearList();
+        return;
+    }
+
+    for (const auto& point : selected) {
+        point->setSelected(false);
+        if (auto *smartPoint = dynamic_cast<SmartNodePoint*>(point)) {
+            smartPoint->actionRemove(true);
+        } else {
+            point->remove();
+        }
+    }
+    mSelectedPoints_d.clear();
+    emit pointSelectionChanged();
+    schedulePivotUpdate();
+}
+
+
 void Canvas::clearPointsSelection() {
     for(const auto& point : mSelectedPoints_d) {
         if(point) point->setSelected(false);

--- a/src/ui/widgets/toolbox.cpp
+++ b/src/ui/widgets/toolbox.cpp
@@ -288,6 +288,11 @@ void ToolBox::setupNodesAction(const QIcon &icon,
         case NodeNew:
             mActions.subdivideSegments();
             break;
+        case NodeRemove:
+            if (mActions.deleteAction) {
+                (*mActions.deleteAction)();
+            }
+            break;
         case NodeSymmetric:
             mActions.makePointCtrlsSymmetric();
             break;
@@ -324,6 +329,8 @@ void ToolBox::setupNodesActions()
                      tr("Merge Nodes"), NodeMerge);
     setupNodesAction(QIcon::fromTheme("nodeNew"),
                      tr("New Node"), NodeNew);
+    setupNodesAction(QIcon::fromTheme("nodeRemove"),
+                     tr("Remove Node"), NodeRemove);
     setupNodesAction(QIcon::fromTheme("nodeSymmetric"),
                      tr("Symmetric Nodes"), NodeSymmetric);
     setupNodesAction(QIcon::fromTheme("nodeSmooth"),

--- a/src/ui/widgets/toolbox.cpp
+++ b/src/ui/widgets/toolbox.cpp
@@ -293,6 +293,9 @@ void ToolBox::setupNodesAction(const QIcon &icon,
                 (*mActions.deleteAction)();
             }
             break;
+        case NodeRemoveApprox:
+            mActions.removePointsApprox();
+            break;
         case NodeSymmetric:
             mActions.makePointCtrlsSymmetric();
             break;
@@ -331,6 +334,8 @@ void ToolBox::setupNodesActions()
                      tr("New Node"), NodeNew);
     setupNodesAction(QIcon::fromTheme("nodeRemove"),
                      tr("Remove Node"), NodeRemove);
+    setupNodesAction(QIcon::fromTheme("nodeRemoveApprox"),
+                     tr("Remove Node Approx."), NodeRemoveApprox);
     setupNodesAction(QIcon::fromTheme("nodeSymmetric"),
                      tr("Symmetric Nodes"), NodeSymmetric);
     setupNodesAction(QIcon::fromTheme("nodeSmooth"),

--- a/src/ui/widgets/toolbox.h
+++ b/src/ui/widgets/toolbox.h
@@ -55,6 +55,7 @@ namespace Friction
                 NodeDisconnect,
                 NodeMerge,
                 NodeNew,
+                NodeRemove,
                 NodeSymmetric,
                 NodeSmooth,
                 NodeCorner,

--- a/src/ui/widgets/toolbox.h
+++ b/src/ui/widgets/toolbox.h
@@ -56,6 +56,7 @@ namespace Friction
                 NodeMerge,
                 NodeNew,
                 NodeRemove,
+                NodeRemoveApprox,
                 NodeSymmetric,
                 NodeSmooth,
                 NodeCorner,


### PR DESCRIPTION
Since some time I'm missing exposed icons for node removal, I know you can do it with the keyboard or secondary mouse button but it seems like they are missing in the toolbox by a UX dimension:

![remove_nodes_screenshot](https://github.com/user-attachments/assets/b58dfb84-03f8-4ddb-8aa9-0183ffdec6e5)

<img width="166" height="80" alt="remove_nodes" src="https://github.com/user-attachments/assets/1a1dfbb3-d5d9-45a8-8d08-f19e9fe8200a" />
