### PR TITLE
UX: place timebar on first scene frame at scene creation

### DIFF
--- a/src/ui/dialogs/scenesettingsdialog.cpp
+++ b/src/ui/dialogs/scenesettingsdialog.cpp
@@ -362,6 +362,7 @@ void SceneSettingsDialog::sNewSceneDialog(Document& document,
         const auto newCanvas = docPtr->createNewScene();
         const auto block = newCanvas->blockUndoRedo();
         dialog->applySettingsToCanvas(newCanvas);
+        newCanvas->anim_setAbsFrame(newCanvas->getFrameRange().fMin);
         dialog->close();
         docPtr->actionFinished();
     });


### PR DESCRIPTION
Simple UX thing but handy if your scenes not always start at frame 0: place timebar at fMin (first scene frame) at scene creation so that you can start adding keyframes without the need to move it to the first real scene frame 😄