### PR TITLE
UX: add a new gizmo when X or Y fixed translation is in action v2 (compatible with gizmos-v1.7)

### DIFF
--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -1015,11 +1015,15 @@ bool Canvas::handleTransormationInputKeyEvent(const eKeyEvent &e)
     } else if (e.fKey == Qt::Key_X) {
         if (e.fAutorepeat) { return false; }
         mValueInput.switchXOnlyMode();
+        const bool linesChanged = updateLineGizmoVisibility();
         updateTransformation(e);
+        if (linesChanged) { emit requestUpdate(); }
     } else if (e.fKey == Qt::Key_Y) {
         if (e.fAutorepeat) { return false; }
         mValueInput.switchYOnlyMode();
+        const bool linesChanged = updateLineGizmoVisibility();
         updateTransformation(e);
+        if (linesChanged) { emit requestUpdate(); }
     } else { return false; }
     return true;
 }

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -776,6 +776,10 @@ private:
     void setRotateHandleHover(bool hovered);
     void setGizmosSuppressed(bool suppressed);
 
+    bool shouldShowXLineGizmo() const;
+    bool shouldShowYLineGizmo() const;
+    bool updateLineGizmoVisibility();
+
     void updateRotateHandleGeometry(qreal invScale);
 
     bool tryStartRotateWithGizmo(const eMouseEvent &e,

--- a/src/core/gizmos.h
+++ b/src/core/gizmos.h
@@ -96,6 +96,14 @@ namespace Friction
                 QVector<QPointF> polygonPoints;
             };
 
+            struct LineGeometry
+            {
+                QPointF start;
+                QPointF end;
+                qreal strokeWidth = 0.0;
+                bool visible = false;
+            };
+
             struct Config
             {
                 qreal rotateSweepDeg = 90.0; // default sweep of gizmo arc
@@ -115,6 +123,10 @@ namespace Friction
                 qreal shearRadiusPx = 6.0; // shear gizmo circle radius in screen pixels
                 // TODO? this is not used
                 qreal shearGapPx = 2.0; // gap between scale and shear gizmos in screen pixels
+                qreal xLineLengthPx = 100.0; // length of the XLine gizmo in screen pixels
+                qreal xLineStrokePx = 2.0; // stroke thickness for the XLine gizmo in screen pixels
+                qreal yLineLengthPx = 100.0; // length of the YLine gizmo in screen pixels
+                qreal yLineStrokePx = 2.0; // stroke thickness for the YLine gizmo in screen pixels
             };
 
             struct Theme
@@ -153,6 +165,8 @@ namespace Friction
                 ScaleGeometry scaleUniformGeom;
                 ShearGeometry shearXGeom;
                 ShearGeometry shearYGeom;
+                LineGeometry xLineGeom;
+                LineGeometry yLineGeom;
                 bool axisXHovered = false;
                 bool axisYHovered = false;
                 bool axisUniformHovered = false;


### PR DESCRIPTION
Very handy and nice, other softwares do the same way:

<img width="1369" height="814" alt="Screenshot 2025-10-05 at 21 40 38" src="https://github.com/user-attachments/assets/81a9ad25-35f6-4413-bc2c-4d0ea7c096b4" />

I'm closing https://github.com/friction2d/friction/pull/610 as it is outdated.