### PR TITLE
UX: add "+" button to bookmarked colors and icon+title

### DIFF
--- a/src/ui/widgets/savedcolorswidget.h
+++ b/src/ui/widgets/savedcolorswidget.h
@@ -48,7 +48,6 @@ public:
     void setColor(const QColor& color);
 
 private:
-    void setupBookmarkButton();
     void addBookmarkButton();
 
     FlowLayout *mMainLayout = nullptr;


### PR DESCRIPTION
It's a pretty simple tweak but I think it add "color bookmark" discoverability and makes easier to add new ones.
The button adds selected color for single ones or active color from a gradient.

<img width="354" height="397" alt="Screenshot 2025-10-24 at 12 25 57" src="https://github.com/user-attachments/assets/7d8c2e24-599b-4a21-a18e-e2fc2807625e" />

The style matches the one proposed in a previous PR https://github.com/friction2d/friction/pull/629