### PR TITLE
Duplicate effect: add rotation and pivot updates on change

### DIFF
--- a/src/core/Animators/transformanimator.cpp
+++ b/src/core/Animators/transformanimator.cpp
@@ -423,9 +423,11 @@ void AdvancedTransformAnimator::setPivotFixedTransform(
     } else if(posAnimated && !pivotAnimated) {
         mPosAnimator->incAllBaseValues(posXInc, posYInc);
         mPivotAnimator->setBaseValueWithoutCallingUpdater(newPivot);
+        mPivotAnimator->prp_afterChangedCurrent(UpdateReason::userChange);
     } else { // if(!posAnimated && !pivotAnimated) {
         mPosAnimator->incBaseValuesWithoutCallingUpdater(posXInc, posYInc);
         mPivotAnimator->setBaseValueWithoutCallingUpdater(newPivot);
+        mPivotAnimator->prp_afterChangedCurrent(UpdateReason::userChange);
     }
 }
 

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -85,8 +85,14 @@ BoundingBox::BoundingBox(const QString& name, const eBoxType type) :
 
     ca_addChild(mTransformAnimator);
     const auto pivotAnim = mTransformAnimator->getPivotAnimator();
-    connect(pivotAnim, &Property::prp_currentFrameChanged,
-            this, &BoundingBox::requestGlobalPivotUpdateIfSelected);
+    if(pivotAnim) {
+        connect(pivotAnim, &Property::prp_currentFrameChanged,
+                this, [this](const UpdateReason reason) {
+                    requestGlobalPivotUpdateIfSelected();
+                    planUpdate(reason);
+                    onPivotChanged(reason);
+                });
+    }
 
     ca_addChild(mRasterEffectsAnimators);
     mRasterEffectsAnimators->SWT_hide();
@@ -1035,6 +1041,8 @@ void BoundingBox::setAbsolutePos(const QPointF &pos) {
 void BoundingBox::setRelativePos(const QPointF &relPos) {
     mTransformAnimator->setPosition(relPos.x(), relPos.y());
 }
+
+void BoundingBox::onPivotChanged(const UpdateReason) {}
 
 void BoundingBox::setOpacity(const qreal opacity) {
     mTransformAnimator->setOpacity(opacity);

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -342,6 +342,9 @@ public:
 
     void setPivotAbsPos(const QPointF &absPos);
     void setPivotRelPos(const QPointF &relPos);
+protected:
+    virtual void onPivotChanged(const UpdateReason reason);
+public:
 
     bool isAnimated() const;
 

--- a/src/core/Boxes/boxwithpatheffects.cpp
+++ b/src/core/Boxes/boxwithpatheffects.cpp
@@ -323,6 +323,14 @@ void BoxWithPathEffects::addOutlineEffects(const qreal relFrame,
     parent->addOutlineEffects(parentRelFrame, list, influence);
 }
 
+void BoxWithPathEffects::onPivotChanged(const UpdateReason reason) {
+    BoundingBox::onPivotChanged(reason);
+    mPathEffectsAnimators->prp_afterChangedCurrent(reason);
+    mFillPathEffectsAnimators->prp_afterChangedCurrent(reason);
+    mOutlineBasePathEffectsAnimators->prp_afterChangedCurrent(reason);
+    mOutlinePathEffectsAnimators->prp_afterChangedCurrent(reason);
+}
+
 void BoxWithPathEffects::getMotionBlurProperties(QList<Property*> &list) const {
     BoundingBox::getMotionBlurProperties(list);
     list.append(mPathEffectsAnimators.get());

--- a/src/core/Boxes/boxwithpatheffects.h
+++ b/src/core/Boxes/boxwithpatheffects.h
@@ -102,6 +102,7 @@ public:
                            PathCallerList& list,
                            const qreal influence = 1) const;
 protected:
+    void onPivotChanged(const UpdateReason reason) override;
     void getMotionBlurProperties(QList<Property*> &list) const;
 
     qsptr<PathEffectCollection> mPathEffectsAnimators;

--- a/src/core/PathEffects/duplicatepatheffect.h
+++ b/src/core/PathEffects/duplicatepatheffect.h
@@ -28,6 +28,8 @@
 #include "PathEffects/patheffect.h"
 class IntAnimator;
 class QPointFAnimator;
+class QrealAnimator;
+class BoolProperty;
 
 class CORE_EXPORT DuplicatePathEffect : public PathEffect {
     e_OBJECT
@@ -35,11 +37,14 @@ protected:
     DuplicatePathEffect();
 public:
     stdsptr<PathEffectCaller> getEffectCaller(
-            const qreal relFrame, const qreal influence) const;
-    bool skipZeroInfluence(const qreal relFrame) const;
+            const qreal relFrame, const qreal influence) const override;
+    bool skipZeroInfluence(const qreal relFrame) const override;
 private:
-    qsptr<IntAnimator> mCount;
     qsptr<QPointFAnimator> mTranslation;
+    qsptr<QrealAnimator> mRotation;
+    qsptr<IntAnimator> mCount;
+    qsptr<BoolProperty> mUseCustomPivot;
+    qsptr<QPointFAnimator> mCustomPivot;
 };
 
 #endif // DUPLICATEPATHEFFECT_H


### PR DESCRIPTION
Slightly related with this feature request, I added rotation and rotation origin support to "duplicate effect":

![duplicate_and_rotation](https://github.com/user-attachments/assets/99fb394b-c46f-45ae-bb7b-b60a8543df1f)

It changes things so I guess we would need too move it to v1.1 (and therefore work on new format too...)