### PR TITLE
node tangents snapping

### DIFF
--- a/src/core/MovablePoints/smartctrlpoint.h
+++ b/src/core/MovablePoints/smartctrlpoint.h
@@ -35,6 +35,7 @@ protected:
     SmartCtrlPoint(SmartNodePoint * const parentPoint,
                    const Type &type);
 public:
+    SmartNodePoint* getParentPoint() const { return mParentPoint_k; }
     void drawSk(SkCanvas* const canvas,
                 const CanvasMode mode,
                 const float invScale,

--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -1286,6 +1286,7 @@ bool Canvas::startScalingAction(const eKeyEvent &e)
     }
     mValueInput.clearAndDisableInput();
     mValueInput.setupScale();
+    mLastPointMoveBy = QPointF();
 
     mRotPivot->setMousePos(e.fPos);
     mTransMode = TransformMode::scale;
@@ -1301,6 +1302,7 @@ bool Canvas::startMovingAction(const eKeyEvent &e)
         mCurrentMode != CanvasMode::pointTransform) { return false; }
     mValueInput.clearAndDisableInput();
     mValueInput.setupMove();
+    mLastPointMoveBy = QPointF();
 
     mTransMode = TransformMode::move;
     mDoubleClick = false;

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -935,6 +935,7 @@ protected:
     bool mStartTransform = false;
     bool mSelecting = false;
 //    bool mMoving = false;
+    QPointF mLastPointMoveBy;
 
     QRectF mSelectionRect;
     CanvasMode mCurrentMode = CanvasMode::boxTransform;

--- a/src/core/canvasmouseinteractions.cpp
+++ b/src/core/canvasmouseinteractions.cpp
@@ -852,9 +852,14 @@ void Canvas::rotateSelected(const eMouseEvent& e)
         rot = d_rot + mRotHalfCycles*180;
     }
 
-    if (!mValueInput.inputEnabled() && e.shiftMod()) {
-        constexpr qreal snapStep = 15.0;
-        rot = std::round(rot / snapStep) * snapStep;
+    if (!mValueInput.inputEnabled()) {
+        if (e.ctrlMod()) {
+            constexpr qreal snapStep = 1.0;
+            rot = std::round(rot / snapStep) * snapStep;
+        } else if (e.shiftMod()) {
+            constexpr qreal snapStep = 15.0;
+            rot = std::round(rot / snapStep) * snapStep;
+        }
     }
 
     if (mCurrentMode == CanvasMode::boxTransform) {

--- a/src/core/canvasmouseinteractions.cpp
+++ b/src/core/canvasmouseinteractions.cpp
@@ -60,6 +60,7 @@
 #include <QMenu>
 #include <QInputDialog>
 #include <QApplication>
+#include <cmath>
 
 using namespace Friction::Core;
 
@@ -849,6 +850,11 @@ void Canvas::rotateSelected(const eMouseEvent& e)
         else if (mLastDRot - d_rot < -90) { mRotHalfCycles -= 2; }
         mLastDRot = d_rot;
         rot = d_rot + mRotHalfCycles*180;
+    }
+
+    if (!mValueInput.inputEnabled() && e.shiftMod()) {
+        constexpr qreal snapStep = 15.0;
+        rot = std::round(rot / snapStep) * snapStep;
     }
 
     if (mCurrentMode == CanvasMode::boxTransform) {


### PR DESCRIPTION
Related with https://github.com/friction2d/friction/issues/250 and https://github.com/friction2d/friction/pull/628#issuecomment-3534946253

While rotating you can use `shift` modifier for 15º snapping or `ctrl/cmd` for 1º snapping.
It's indeed compatible with numerical input (it doesn't block it), rotating with `R` and gizmo.

Note that it is a **stepped rotation** by 15 or 1 degrees **starting with the original rotation value**  the object had, it is not a snapping rotation where the rotation snaps to "previously fixed canvas rotations" (0º, 15º, 30º, ...). BTW, it's the way Inkscape and other software does it.

Further implementation would be using variables instead, so the rotation steps are configurable via **Preferences** and make the modifier also configurable (this is more related with shortcuts configuration...), but I don't know if that part should wait for v1.1 as it needs to change that panel... let me know what do you think and we find the right place.

I'm going to investigate if this feature can be as easily be implemented for node tangents too...