### PR TITLE
Fix color parameter

### DIFF
--- a/src/app/GUI/BoxesList/boxsinglewidget.cpp
+++ b/src/app/GUI/BoxesList/boxsinglewidget.cpp
@@ -264,8 +264,8 @@ BoxSingleWidget::BoxSingleWidget(BoxScroller * const parent)
 
     mColorButton = new ColorAnimatorButton(nullptr, this);
     mMainLayout->addWidget(mColorButton, Qt::AlignRight);
-    mColorButton->setFixedHeight(mColorButton->height() - 6);
-    mColorButton->setContentsMargins(0, 3, 0, 3);
+    mColorButton->setFixedHeight(mColorButton->height() - 2);
+    mColorButton->setContentsMargins(0, 1, 0, 1);
 
     mPropertyComboBox = createCombo(this);
     mMainLayout->addWidget(mPropertyComboBox);

--- a/src/core/GUI/coloranimatorbutton.cpp
+++ b/src/core/GUI/coloranimatorbutton.cpp
@@ -73,6 +73,7 @@ void ColorAnimatorButton::paintEvent(QPaintEvent *)
 {
     QPainter p(this);
 
+    const QColor currentColor = color();
     const QRectF rect(0.0, 0.0, width(), height());
     const float borderWidth = 2.0;
     const QRectF innerRect = rect.adjusted(borderWidth,
@@ -81,19 +82,19 @@ void ColorAnimatorButton::paintEvent(QPaintEvent *)
                                            -borderWidth);
 
     if (mHover) {
-        const QColor color = ThemeSupport::getLightDarkColor(mColor, 130);
+        const QColor color = ThemeSupport::getLightDarkColor(currentColor, 130);
         p.setPen(color);
         p.setBrush(color);
         p.drawRoundedRect(rect,
                           borderWidth + 2,
                           borderWidth + 2);
-        p.setBrush(mColor);
+        p.setBrush(currentColor);
         p.drawRoundedRect(innerRect,
                           borderWidth,
                           borderWidth);
     } else {
-        p.setPen(mColor);
-        p.setBrush(mColor);
+        p.setPen(currentColor);
+        p.setBrush(currentColor);
         p.drawRoundedRect(rect,
                           borderWidth + 2,
                           borderWidth + 2);

--- a/src/core/GUI/coloranimatorbutton.cpp
+++ b/src/core/GUI/coloranimatorbutton.cpp
@@ -36,6 +36,10 @@ ColorAnimatorButton::ColorAnimatorButton(QWidget * const parent)
 {
     connect(this, &BoxesListActionButton::pressed,
             this, &ColorAnimatorButton::openColorSettingsDialog);
+    eSizesUI::widget.add(this, [this](const int size) {
+        setFixedHeight(size);
+        setFixedWidth(size * 3 - 2);
+    });
 }
 
 ColorAnimatorButton::ColorAnimatorButton(ColorAnimator * const colorTarget,


### PR DESCRIPTION
As commented by user @nuxttux [here](https://github.com/friction2d/friction/pull/679#issuecomment-3706671982), this is the fix for the `colorAnimatorButton` actual color preview.

In the way I also tweaked the size to better match other widgets in the parameter timeline hierarchy:

<img width="365" height="266" alt="Screenshot 2026-01-03 at 16 46 57" src="https://github.com/user-attachments/assets/12465dec-d563-4c82-b9f4-faecd669fe2a" />
