### PR TITLE
add Expression Presets for easy "frame remapping"

### DIFF
--- a/src/core/Expressions/expressionpresets.cpp
+++ b/src/core/Expressions/expressionpresets.cpp
@@ -372,6 +372,8 @@ void ExpressionPresets::firstRun()
     QStringList presets;
     presets << "copyX.fexpr";
     presets << "copyY.fexpr";
+    presets << "frameRemapLoop.fexpr";
+    presets << "frameRemapLoopBounce.fexpr";
     presets << "noise.fexpr";
     presets << "orbitX.fexpr";
     presets << "orbitY.fexpr";

--- a/src/core/Expressions/presets/frameRemapLoop.fexpr
+++ b/src/core/Expressions/presets/frameRemapLoop.fexpr
@@ -1,0 +1,13 @@
+[General]
+author=pgilfernandez
+bindings="frame = $frame;\n"
+categories=
+definitions=
+description="Loop a linked scene with FRAME REMAPPING activated:\n1) create a scene you want to loop\n2) link that scene into another one\n3) select the linked scene object and choose FRAME REMAPPING\n4) select FRAME parameter and apply this preset to it\n5) change the LOOP_FPS value to your original loop scene size"
+highlighters=
+id=graphics.friction.frameRemapLoop
+license=
+script="loop_fps =  120; // change with your loop frame count\ntime = frame % loop_fps;\nreturn time"
+title=Frame Remap Loop
+url=
+version=1

--- a/src/core/Expressions/presets/frameRemapLoopBounce.fexpr
+++ b/src/core/Expressions/presets/frameRemapLoopBounce.fexpr
@@ -1,0 +1,13 @@
+[General]
+author=pgilfernandez
+bindings="frame = $frame;\n"
+categories=
+definitions=
+description="Bounce loop a linked scene with FRAME REMAPPING activated:\n1) create a scene you want to loop\n2) link that scene into another one\n3) select the linked scene object and choose FRAME REMAPPING\n4) select FRAME parameter and apply this preset to it\n5) change the LOOP_FPS value to your original loop scene size"
+highlighters=
+id=graphics.friction.frameRemapLoopBounce
+license=
+script="loop_fps =  120; // change with your loop frame count\nperiod = loop_fps * 2;\nt = frame % period;\nreturn t < loop_fps ? t : (period - t);"
+title=Frame Remap Loop (bounce)
+url=
+version=1

--- a/src/core/coreresources.qrc
+++ b/src/core/coreresources.qrc
@@ -26,6 +26,8 @@
         <file alias="lerp.fexpr">Expressions/presets/lerp.fexpr</file>
         <file alias="copyX.fexpr">Expressions/presets/copyX.fexpr</file>
         <file alias="copyY.fexpr">Expressions/presets/copyY.fexpr</file>
+        <file alias="frameRemapLoop.fexpr">Expressions/presets/frameRemapLoop.fexpr</file>
+        <file alias="frameRemapLoopBounce.fexpr">Expressions/presets/frameRemapLoopBounce.fexpr</file>
         <file alias="noise.fexpr">Expressions/presets/noise.fexpr</file>
         <file alias="orbitX.fexpr">Expressions/presets/orbitX.fexpr</file>
         <file alias="orbitY.fexpr">Expressions/presets/orbitY.fexpr</file>


### PR DESCRIPTION
Frame remapping is already in Friction and user may be able to guess how to use expressions to take advantage of the feature but these 2 simple expressions make it super easy:

![frame_remap_expressions](https://github.com/user-attachments/assets/69f03d33-9255-46b4-99ea-c99abc2d2a90)

Related to this, I remembered that our expressions presets have a `description` field, we should somehow expose them in the Expressions Editor so that users understand or learn what an specific preset is used for, what do you think @rodlie?