### PR TITLE
add Expressions to text parameter

### DIFF
--- a/src/app/GUI/Dialogs/dialogsinterfaceimpl.cpp
+++ b/src/app/GUI/Dialogs/dialogsinterfaceimpl.cpp
@@ -97,6 +97,13 @@ void DialogsInterfaceImpl::showExpressionDialog(QrealAnimator* const target) con
     dialog->show();
 }
 
+void DialogsInterfaceImpl::showExpressionDialog(QStringAnimator* const target) const {
+    const auto parent = MainWindow::sGetInstance();
+    const auto dialog = new ExpressionDialog(target, parent);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
+}
+
 void DialogsInterfaceImpl::showApplyExpressionDialog(QrealAnimator* const target) const {
     const auto parent = MainWindow::sGetInstance();
     const auto dialog = new ApplyExpressionDialog(target, parent);

--- a/src/app/GUI/Dialogs/dialogsinterfaceimpl.h
+++ b/src/app/GUI/Dialogs/dialogsinterfaceimpl.h
@@ -34,6 +34,7 @@ public:
     stdsptr<ShaderEffectCreator> execShaderChooser(
             const QString& name, const ShaderOptions& options) const;
     void showExpressionDialog(QrealAnimator* const target) const;
+    void showExpressionDialog(QStringAnimator* const target) const;
     void showApplyExpressionDialog(QrealAnimator* const target) const;
     void showDurationSettingsDialog(DurationRectangle* const target) const;
     /*bool execAnimationToPaint(const AnimationBox* const src,

--- a/src/app/GUI/Expressions/expressioneditor.cpp
+++ b/src/app/GUI/Expressions/expressioneditor.cpp
@@ -30,11 +30,7 @@
 #include "expressionhighlighter.h"
 #include "themesupport.h"
 
-ExpressionEditor::ExpressionEditor(QrealAnimator * const target,
-                                   QWidget * const parent) :
-    ExpressionEditor(target, target->getExpressionBindingsString(), parent) {}
-
-ExpressionEditor::ExpressionEditor(QrealAnimator * const target,
+ExpressionEditor::ExpressionEditor(Property * const target,
                                    const QString &text,
                                    QWidget * const parent)
     : QTextEdit(parent)
@@ -197,4 +193,3 @@ QString ExpressionEditor::textUnderCursor() const {
     }
     return result;
 }
-

--- a/src/app/GUI/Expressions/expressioneditor.h
+++ b/src/app/GUI/Expressions/expressioneditor.h
@@ -33,7 +33,7 @@
 #include <QAbstractItemView>
 
 #include "GUI/global.h"
-#include "Animators/qrealanimator.h"
+#include "Properties/property.h"
 
 class ExpressionHighlighter;
 
@@ -42,10 +42,7 @@ class ExpressionEditor : public QTextEdit
     Q_OBJECT
 
 public:
-    ExpressionEditor(QrealAnimator* const target,
-                     QWidget* const parent);
-
-    ExpressionEditor(QrealAnimator* const target,
+    ExpressionEditor(Property* const target,
                      const QString& text, QWidget* const parent);
 
     void setCompleterList(const QStringList& values);

--- a/src/app/GUI/Expressions/expressionhighlighter.cpp
+++ b/src/app/GUI/Expressions/expressionhighlighter.cpp
@@ -32,7 +32,7 @@
 #include "expressioneditor.h"
 
 ExpressionHighlighter::ExpressionHighlighter(
-        QrealAnimator * const target,
+        Property * const target,
         ExpressionEditor * const editor,
         QTextDocument *parent) :
     QSyntaxHighlighter(parent),

--- a/src/app/GUI/Expressions/expressionhighlighter.h
+++ b/src/app/GUI/Expressions/expressionhighlighter.h
@@ -28,13 +28,13 @@
 
 #include <QSyntaxHighlighter>
 
-#include "Animators/qrealanimator.h"
+#include "Properties/property.h"
 
 class ExpressionEditor;
 
 class ExpressionHighlighter : public QSyntaxHighlighter {
 public:
-    ExpressionHighlighter(QrealAnimator* const target,
+    ExpressionHighlighter(Property* const target,
                           ExpressionEditor* const editor,
                           QTextDocument *parent);
 
@@ -68,7 +68,7 @@ private:
     QStringList mBaseComplete;
     QStringList mBaseVarsComplete;
 
-    QrealAnimator* const mTarget;
+    Property* const mTarget;
     ComplexAnimator* const mSearchCtxt;
     ExpressionEditor* const mEditor;
 };

--- a/src/core/Animators/qstringanimator.cpp
+++ b/src/core/Animators/qstringanimator.cpp
@@ -29,9 +29,45 @@
 #include "simplemath.h"
 #include "svgexporthelpers.h"
 #include "appsupport.h"
+#include "simpletask.h"
+#include "ReadWrite/evformat.h"
+#include "typemenu.h"
+#include "GUI/dialogsinterface.h"
+#include "Expressions/expression.h"
+#include "canvas.h"
 
 QStringAnimator::QStringAnimator(const QString &name) :
     SteppedAnimator<QString>(name) {}
+
+void QStringAnimator::prp_writeProperty_impl(eWriteStream& dst) const {
+    SteppedAnimator<QString>::prp_writeProperty_impl(dst);
+    dst << !!mExpression;
+    if(mExpression) {
+        dst << mExpression->bindingsString();
+        dst << mExpression->definitionsString();
+        dst << mExpression->scriptString();
+    }
+}
+
+void QStringAnimator::prp_readProperty_impl(eReadStream& src) {
+    SteppedAnimator<QString>::prp_readProperty_impl(src);
+
+    if(src.evFileVersion() >= EvFormat::textExpression) {
+        bool hasExpr = false;
+        src >> hasExpr;
+        if(hasExpr) {
+            QString bindingsStr; src >> bindingsStr;
+            QString definitionsStr; src >> definitionsStr;
+            QString scriptStr; src >> scriptStr;
+            SimpleTask::sScheduleContexted(this,
+            [this, bindingsStr, definitionsStr, scriptStr]() {
+                setExpression(Expression::sCreate(
+                                  bindingsStr, definitionsStr, scriptStr, this,
+                                  Expression::sQStringAnimatorTester));
+            });
+        }
+    }
+}
 
 QDomElement createTextElement(SvgExporter& exp, const QString& text) {
     auto textEle = exp.createElement("text");
@@ -75,6 +111,237 @@ void QStringAnimator::saveSVG(SvgExporter& exp, QDomElement& parent,
     }
 }
 
+QJSValue QStringAnimator::prp_getBaseJSValue(QJSEngine& e) const {
+    Q_UNUSED(e)
+    return getBaseValueAtRelFrame(anim_getCurrentRelFrame());
+}
+
+QJSValue QStringAnimator::prp_getBaseJSValue(QJSEngine& e,
+                                             const qreal relFrame) const {
+    Q_UNUSED(e)
+    return getBaseValueAtRelFrame(relFrame);
+}
+
+QJSValue QStringAnimator::prp_getEffectiveJSValue(QJSEngine& e) const {
+    Q_UNUSED(e)
+    return getEffectiveValue(anim_getCurrentRelFrame());
+}
+
+QJSValue QStringAnimator::prp_getEffectiveJSValue(QJSEngine& e,
+                                                  const qreal relFrame) const {
+    Q_UNUSED(e)
+    return getEffectiveValue(relFrame);
+}
+
+void QStringAnimator::prp_setupTreeViewMenu(PropertyMenu * const menu) {
+    if(menu->hasActionsForType<QStringAnimator>()) { return; }
+    menu->addedActionsForType<QStringAnimator>();
+
+    const PropertyMenu::PlainSelectedOp<QStringAnimator> sOp =
+    [](QStringAnimator * aTarget) {
+        const auto& iface = DialogsInterface::instance();
+        iface.showExpressionDialog(aTarget);
+    };
+    menu->addPlainAction(QIcon::fromTheme("preferences"),
+                         tr("Set Expression"), sOp);
+
+    const PropertyMenu::PlainSelectedOp<QStringAnimator> aOp =
+    [](QStringAnimator * aTarget) {
+        const auto scene = aTarget->getFirstAncestor<Canvas>();
+        if(!scene) return;
+        const auto relRange = aTarget->prp_absRangeToRelRange(
+                    scene->getFrameRange());
+        aTarget->applyExpression(relRange, true);
+    };
+    menu->addPlainAction(QIcon::fromTheme("dialog-ok"),
+                         tr("Apply Expression"), aOp)->setEnabled(hasExpression());
+
+    const PropertyMenu::PlainSelectedOp<QStringAnimator> cOp =
+    [](QStringAnimator * aTarget) {
+        aTarget->clearExpressionAction();
+    };
+    menu->addPlainAction(QIcon::fromTheme("trash"),
+                         tr("Clear Expression"), cOp)->setEnabled(hasExpression());
+
+    menu->addSeparator();
+    Animator::prp_setupTreeViewMenu(menu);
+}
+
+FrameRange QStringAnimator::prp_getIdenticalRelRange(const int relFrame) const {
+    const auto base = SteppedAnimator<QString>::prp_getIdenticalRelRange(relFrame);
+    if(mExpression) {
+        const int absFrame = prp_relFrameToAbsFrame(relFrame);
+        return base * mExpression->identicalRelRange(absFrame);
+    }
+    return base;
+}
+
+FrameRange QStringAnimator::prp_nextNonUnaryIdenticalRelRange(
+        const int relFrame) const {
+    if(hasExpression()) {
+        const int absFrame = prp_relFrameToAbsFrame(relFrame);
+        for(int i = relFrame, j = absFrame; i < FrameRange::EMAX; i++, j++) {
+            FrameRange range{FrameRange::EMIN, FrameRange::EMAX};
+            int lowestMax = INT_MAX;
+
+            {
+                const auto childRange =
+                        SteppedAnimator<QString>::prp_nextNonUnaryIdenticalRelRange(i);
+                lowestMax = qMin(lowestMax, childRange.fMax);
+                range *= childRange;
+            }
+            {
+                const auto childRange = mExpression->nextNonUnaryIdenticalRelRange(j);
+                lowestMax = qMin(lowestMax, childRange.fMax);
+                range *= childRange;
+            }
+
+            if(!range.isUnary()) return range;
+            const int di = lowestMax - i;
+            i += di;
+            j += di;
+        }
+        return FrameRange::EMINMAX;
+    }
+    return SteppedAnimator<QString>::prp_nextNonUnaryIdenticalRelRange(relFrame);
+}
+
+void QStringAnimator::prp_afterFrameShiftChanged(
+        const FrameRange& oldAbsRange,
+        const FrameRange& newAbsRange) {
+    SteppedAnimator<QString>::prp_afterFrameShiftChanged(oldAbsRange, newAbsRange);
+    updateExpressionRelFrame();
+}
+
+void QStringAnimator::anim_setAbsFrame(const int frame) {
+    SteppedAnimator<QString>::anim_setAbsFrame(frame);
+    const bool exprFrameChanged = updateExpressionRelFrame();
+    const bool exprValueChanged = updateCurrentEffectiveValue();
+    if(exprFrameChanged || exprValueChanged) {
+        prp_afterChangedCurrent(UpdateReason::frameChange);
+    }
+}
+
+bool QStringAnimator::prp_dependsOn(const Property* const prop) const {
+    if(!mExpression) return false;
+    return mExpression->dependsOn(prop);
+}
+
+bool QStringAnimator::hasValidExpression() const {
+    return mExpression ? mExpression->isValid() : false;
+}
+
+QString QStringAnimator::getExpressionBindingsString() const {
+    if(!mExpression) return "";
+    return mExpression->bindingsString();
+}
+
+QString QStringAnimator::getExpressionDefinitionsString() const {
+    if(!mExpression) return "";
+    return mExpression->definitionsString();
+}
+
+QString QStringAnimator::getExpressionScriptString() const {
+    if(!mExpression) return "";
+    return mExpression->scriptString();
+}
+
+void QStringAnimator::setExpressionAction(const qsptr<Expression>& expression) {
+    if(expression || mExpression) {
+        prp_pushUndoRedoName(tr("Change Expression"));
+        UndoRedo ur;
+        const auto oldValue = mExpression.sptr();
+        const auto newValue = expression;
+        ur.fUndo = [this, oldValue]() { setExpression(oldValue); };
+        ur.fRedo = [this, newValue]() { setExpression(newValue); };
+        prp_addUndoRedo(ur);
+    }
+    setExpression(expression);
+}
+
+void QStringAnimator::setExpression(const qsptr<Expression>& expression) {
+    auto& conn = mExpression.assign(expression);
+    if(expression) {
+        const int absFrame = anim_getCurrentAbsFrame();
+        expression->setAbsFrame(absFrame);
+        conn << connect(expression.get(), &Expression::currentValueChanged,
+                        this, [this]() {
+            if(updateCurrentEffectiveValue()) {
+                prp_afterChangedCurrent(UpdateReason::frameChange);
+            }
+        });
+        conn << connect(expression.get(), &Expression::relRangeChanged,
+                        this, [this](const FrameRange& range) {
+            prp_afterChangedRelRange(range);
+        });
+    }
+    updateCurrentEffectiveValue();
+    prp_afterWholeInfluenceRangeChanged();
+}
+
+void QStringAnimator::applyExpression(const FrameRange& relRange,
+                                      const bool action) {
+    if(!hasValidExpression()) return;
+    if(!relRange.isValid()) return;
+
+    prp_pushUndoRedoName(tr("Apply Expression"));
+
+    QString currentValue;
+    bool first = true;
+    for(int relFrame = relRange.fMin; relFrame <= relRange.fMax; relFrame++) {
+        const int absFrame = prp_relFrameToAbsFrame(relFrame);
+        mExpression->setAbsFrame(absFrame);
+        const QString value = getEffectiveValue(relFrame);
+        if(first || value != currentValue) {
+            currentValue = value;
+            if(auto key = anim_getKeyAtRelFrame<QStringKey>(relFrame)) {
+                key->setValue(value);
+            } else {
+                const auto newKey = enve::make_shared<QStringKey>(value, relFrame, this);
+                if(action) anim_appendKeyAction(newKey);
+                else anim_appendKey(newKey);
+            }
+            first = false;
+        }
+    }
+
+    if(action) { setExpressionAction(nullptr); }
+    else { setExpression(nullptr); }
+}
+
+QString QStringAnimator::getValueAtRelFrame(const qreal frame) const {
+    return getEffectiveValue(frame);
+}
+
+QString QStringAnimator::getBaseValueAtRelFrame(const qreal frame) const {
+    return SteppedAnimator<QString>::getValueAtRelFrame(frame);
+}
+
+QString QStringAnimator::getEffectiveValue(const qreal relFrame) const {
+    if(mExpression) {
+        const auto ret = mExpression->evaluate(relFrame);
+        if(ret.isNull() || ret.isUndefined()) return QString();
+        return ret.toString();
+    }
+    return getBaseValueAtRelFrame(relFrame);
+}
+
+bool QStringAnimator::updateExpressionRelFrame() {
+    if(!mExpression) return false;
+    const int absFrame = anim_getCurrentAbsFrame();
+    return mExpression->setAbsFrame(absFrame);
+}
+
+bool QStringAnimator::updateCurrentEffectiveValue() {
+    if(!mExpression) return false;
+    const auto ret = mExpression->evaluate();
+    if(ret.isNull() || ret.isUndefined()) return false;
+    const QString newValue = ret.toString();
+    if(newValue == mCurrentEffectiveValue) return false;
+    mCurrentEffectiveValue = newValue;
+    return true;
+}
+
 void QStringAnimator::prp_readPropertyXEV_impl(
         const QDomElement& ele, const XevImporter& imp) {
     if(ele.hasAttribute("frames")) {
@@ -97,6 +364,25 @@ void QStringAnimator::prp_readPropertyXEV_impl(
             QTextStream stream(src);
             value = stream.readAll();
             setCurrentValue(value);
+        });
+    }
+
+    const auto expression = ele.firstChildElement("Expression");
+    if(!expression.isNull()) {
+        const auto defsEle =  expression.firstChildElement("Definitions");
+        const QString definitions = defsEle.text();
+
+        const auto bindEle =  expression.firstChildElement("Bindings");
+        const QString bindings = bindEle.text();
+
+        const auto scriptEle =  expression.firstChildElement("Script");
+        const QString script = scriptEle.text();
+
+        SimpleTask::sScheduleContexted(this,
+        [this, bindings, definitions, script]() {
+            setExpression(Expression::sCreate(
+                              bindings, definitions, script, this,
+                              Expression::sQStringAnimatorTester));
         });
     }
 }
@@ -123,6 +409,30 @@ QDomElement QStringAnimator::prp_writePropertyXEV_impl(const XevExporter& exp) c
         result.setAttribute("frames", frames);
     } else {
         saveTextXEV("value.txt", exp, getCurrentValue());
+    }
+
+    if(hasExpression()) {
+        auto expression = exp.createElement("Expression");
+
+        const auto definitions = mExpression->definitionsString();
+        const auto defsNode = exp.createTextNode(definitions);
+        auto defsEle = exp.createElement("Definitions");
+        defsEle.appendChild(defsNode);
+        expression.appendChild(defsEle);
+
+        const auto bindings = mExpression->bindingsString();
+        const auto bindNode = exp.createTextNode(bindings);
+        auto bindEle = exp.createElement("Bindings");
+        bindEle.appendChild(bindNode);
+        expression.appendChild(bindEle);
+
+        const auto script = mExpression->scriptString();
+        const auto scriptNode = exp.createTextNode(script);
+        auto scriptEle = exp.createElement("Script");
+        scriptEle.appendChild(scriptNode);
+        expression.appendChild(scriptEle);
+
+        result.appendChild(expression);
     }
 
     return result;

--- a/src/core/Expressions/expression.cpp
+++ b/src/core/Expressions/expression.cpp
@@ -33,6 +33,12 @@ Expression::ResultTester Expression::sQrealAnimatorTester =
             if(!val.isNumber()) PrettyRuntimeThrow("Invalid return type");
         };
 
+Expression::ResultTester Expression::sQStringAnimatorTester =
+        [](const QJSValue& val) {
+            if(val.isNull() || val.isUndefined())
+                PrettyRuntimeThrow("Invalid return type");
+        };
+
 Expression::Expression(const QString& definitionsStr,
                        const QString& scriptStr,
                        PropertyBindingMap&& bindings,

--- a/src/core/Expressions/expression.h
+++ b/src/core/Expressions/expression.h
@@ -58,6 +58,7 @@ public:
                                      const ResultTester& resultTester);
 
     static ResultTester sQrealAnimatorTester;
+    static ResultTester sQStringAnimatorTester;
 
     bool setAbsFrame(const int absFrame);
 

--- a/src/core/GUI/dialogsinterface.h
+++ b/src/core/GUI/dialogsinterface.h
@@ -30,6 +30,8 @@
 
 class DurationRectangle;
 class AnimationBox;
+class QrealAnimator;
+class QStringAnimator;
 
 using ShaderOptions = QList<stdsptr<ShaderEffectCreator>>;
 
@@ -44,6 +46,8 @@ public:
             const QString& name, const ShaderOptions& options) const = 0;
     virtual void showExpressionDialog(
             QrealAnimator* const target) const = 0;
+    virtual void showExpressionDialog(
+            QStringAnimator* const target) const = 0;
     virtual void showApplyExpressionDialog(
             QrealAnimator* const target) const = 0;
     virtual void showDurationSettingsDialog(

--- a/src/core/ReadWrite/evformat.h
+++ b/src/core/ReadWrite/evformat.h
@@ -47,6 +47,7 @@ namespace EvFormat {
         subPathOffset = 32,
         avStretch = 33,
         grid = 34,
+        textExpression = 35,
 
         nextVersion
     };


### PR DESCRIPTION
I thought this was possible with Friction but I found out I was wrong...

Well, I used IA here to see if he was capable of and the result surprised me, really, here it is:

<img width="1289" height="827" alt="Screenshot 2026-01-08 at 14 14 40" src="https://github.com/user-attachments/assets/4884f500-a034-45c5-81d6-7c123644d929" />

![text_expressions2](https://github.com/user-attachments/assets/d9136478-329f-4929-bbcd-bd45de611da6)

It works like a charm!
It includes "apply expression" and works also on SVGs.

And indeed this is not just for timecodes, fps and similar but anything you could imagine that an expression could return as text 🥳 (subtitles, credits,...)

I haven't tweaked much the code so it needs your always great review @rodlie 😊