### PR TITLE
Parent effect redone

### DIFF
--- a/src/core/TransformEffects/parenteffect.h
+++ b/src/core/TransformEffects/parenteffect.h
@@ -34,6 +34,11 @@ class ParentEffect : public FollowObjectEffectBase
 public:
     ParentEffect();
 
+    void prp_drawCanvasControls(SkCanvas * const canvas,
+                                const CanvasMode mode,
+                                const float invScale,
+                                const bool ctrlPressed) override;
+
     void applyEffect(const qreal relFrame,
                      qreal &pivotX,
                      qreal &pivotY,

--- a/src/core/TransformEffects/parenteffect.h
+++ b/src/core/TransformEffects/parenteffect.h
@@ -48,6 +48,22 @@ public:
                      BoundingBox* const parent) override;
 
 private:
+    void captureBindState(const qreal relFrame);
+    bool ensureBindState(const qreal relFrame);
+
+    bool computeEffectTransform(const qreal relFrame,
+                                const TransformValues& baseValues,
+                                const qreal posXInfl,
+                                const qreal posYInfl,
+                                const qreal scaleXInfl,
+                                const qreal scaleYInfl,
+                                const qreal rotInfl,
+                                QMatrix& outPostTransform,
+                                const bool updateState);
+
+    void handleInfluenceChanged();
+    void updatePrevInfluences(const qreal relFrame);
+
     bool validateInfluenceValues(const qreal posXInfl,
                                  const qreal posYInfl,
                                  const qreal scaleXInfl,
@@ -60,6 +76,22 @@ private:
                                    const qreal posYInfl,
                                    const qreal scaleXInfl,
                                    const qreal scaleYInfl) const;
+
+    QPointF mPrevPosInfluence;
+    QPointF mPrevScaleInfluence;
+    qreal mPrevRotInfluence = 0.0;
+    bool mPrevInfluenceValid = false;
+    QPointF mBindTargetPivotInParent;
+    QPointF mBindObjectPivotInParent;
+    QMatrix mBindTargetLinearInParent;
+    bool mBindStateValid = false;
+    qreal mAccumDeltaAngleRad = 0.0;
+    bool mDeltaAngleStateValid = false;
+    QPointF mNoFollowPivotState;
+    QMatrix mNoFollowLinearState;
+    bool mNoFollowStateValid = false;
+    QPointF mLastBaseMove;
+    bool mLastBaseMoveValid = false;
 };
 
 #endif // PARENTEFFECT_H

--- a/src/core/TransformEffects/parenteffect.h
+++ b/src/core/TransformEffects/parenteffect.h
@@ -88,6 +88,7 @@ private:
     bool mPrevInfluenceValid = false;
     QPointF mBindTargetPivotInParent;
     QPointF mBindObjectPivotInParent;
+    QMatrix mBindTargetParentToParentSpace;
     QMatrix mBindTargetLinearInParent;
     bool mBindStateValid = false;
     qreal mAccumDeltaAngleRad = 0.0;


### PR DESCRIPTION
After fighting with https://github.com/friction2d/friction/issues/707 issue, I ended up doing it with help of AI as the original implementation had some things I didn't like at all (apart from those strange behaviors) and because doing a "parent effect" is doable but adding influences elevates the complexity too much for my skills.

The code includes some special situations that needed special code such as being able to edit the child object (the object with the effect) transform and keep the relationship right and so many more... I hope this is not an inconvenience. In the way I added a visual line that connects the child with the parent when the child is selected, it doesn't change versions so it's safe for v1.0.

I hope you like it!

![parent_effect_v2d](https://github.com/user-attachments/assets/0a69c87b-b5e3-40f5-a212-40cf2181c974)

I'm including here [my test file](https://github.com/user-attachments/files/25162583/parent_influences_v02.friction.zip) in case you want to test the feature, I'm probably mission more situations that I didn't test so it would be necessary to have a look at them all to verify the new code.