### PR TITLE
Linked Scene (crash) fixes

### DIFF
--- a/src/core/Boxes/internallinkcanvas.cpp
+++ b/src/core/Boxes/internallinkcanvas.cpp
@@ -67,6 +67,7 @@ void InternalLinkCanvas::setupRenderData(const qreal relFrame,
                                          const QMatrix& parentM,
                                          BoxRenderData * const data,
                                          Canvas* const scene) {
+    if (!scene) { return; }
     {
         BoundingBox::setupRenderData(relFrame, parentM, data, scene);
         const qreal remapped = mFrameRemapping->frame(relFrame);
@@ -77,6 +78,8 @@ void InternalLinkCanvas::setupRenderData(const qreal relFrame,
     ContainerBox* finalTarget = getFinalTarget();
     auto canvasData = static_cast<LinkCanvasRenderData*>(data);
     const auto canvasTarget = static_cast<Canvas*>(finalTarget);
+    if (!canvasTarget) { return; }
+
     canvasData->fBgColor = toSkColor(canvasTarget->getBgColorAnimator()->
             getColor(relFrame));
     //qreal res = mParentScene->getResolution();
@@ -92,6 +95,11 @@ void InternalLinkCanvas::setupRenderData(const qreal relFrame,
 
 bool InternalLinkCanvas::clipToCanvas() {
     return mClipToCanvas->getValue();
+}
+
+BoundingBox *InternalLinkCanvas::getLinkTarget()
+{
+    return mBoxTarget->getTarget();
 }
 
 qsptr<BoundingBox> InternalLinkCanvas::createLink(const bool inner) {

--- a/src/core/Boxes/internallinkcanvas.h
+++ b/src/core/Boxes/internallinkcanvas.h
@@ -52,6 +52,8 @@ public:
     void disableFrameRemappingAction();
 
     bool clipToCanvas();
+    BoundingBox* getLinkTarget();
+
 private:
     qsptr<BoolProperty> mClipToCanvas =
             enve::make_shared<BoolProperty>("clip");

--- a/src/core/Private/document.cpp
+++ b/src/core/Private/document.cpp
@@ -24,6 +24,7 @@
 // Fork of enve - Copyright (C) 2016-2020 Maurycy Liebner
 
 #include "Private/document.h"
+#include "Boxes/internallinkcanvas.h"
 #include "canvas.h"
 #include "simpletask.h"
 
@@ -243,6 +244,20 @@ bool Document::removeScene(const int id)
     emit sceneRemoved(scene.data());
     emit sceneRemoved(id);
     return true;
+}
+
+bool Document::sceneIsLinked(const qsptr<Canvas> &scene)
+{
+    for (const auto &canvas : fScenes) {
+        for (const auto &box : canvas->getContainedBoxes()) {
+            if (const auto &link = enve_cast<InternalLinkCanvas*>(box)) {
+                if (const auto &target = link->getLinkTarget()) {
+                    if (target->getParentScene() == scene) { return true; }
+                }
+            }
+        }
+    }
+    return false;
 }
 
 void Document::addVisibleScene(Canvas * const scene)

--- a/src/core/Private/document.h
+++ b/src/core/Private/document.h
@@ -157,6 +157,8 @@ public:
     bool removeScene(const qsptr<Canvas>& scene);
     bool removeScene(const int id);
 
+    bool sceneIsLinked(const qsptr<Canvas> &scene);
+
     void addVisibleScene(Canvas * const scene);
     bool removeVisibleScene(Canvas * const scene);
 

--- a/src/core/actions.cpp
+++ b/src/core/actions.cpp
@@ -55,14 +55,21 @@ Actions::Actions(Document &document) : mDocument(document) {
             return static_cast<bool>(mActiveScene);
         };
         const auto deleteSceneActionExec = [this]() {
-            if(!mActiveScene) return false;
+            if (!mActiveScene) { return false; }
             const auto sceneName = mActiveScene->prp_getName();
-            const int buttonId = QMessageBox::question(
-                        nullptr, "Delete " + sceneName,
-                        QString("Are you sure you want to delete "
-                        "%1? This action cannot be undone.").arg(sceneName),
-                        "Cancel", "Delete");
-            if(buttonId == 0) return false;
+            const bool isLinked = mDocument.sceneIsLinked(mActiveScene->ref<Canvas>());
+            if (isLinked) {
+                QMessageBox::information(nullptr,
+                                         tr("Scene is linked"),
+                                         tr("Can't delete %1, it's linked in a different scene.").arg(sceneName));
+                return false;
+            }
+            const int buttonId = QMessageBox::question(nullptr,
+                                                       tr("Delete %1").arg(sceneName),
+                                                       tr("Are you sure you want to delete "
+                                                          "%1? This action cannot be undone.").arg(sceneName),
+                                                       tr("Cancel"), tr("Delete"));
+            if (buttonId == 0) { return false; }
             return mDocument.removeScene(mActiveScene->ref<Canvas>());
         };
         const auto deleteSceneActionText = [this]() {


### PR DESCRIPTION
- Fixes crash when deleting a scene linked in another scene  (you will not be allowed to delete a linked scene)
- Fixes a crash when unselecting (set none) a linked scene target (The link box would crash if set to none)

Fixes https://github.com/friction2d/friction/issues/733