### PR TITLE
Implement canvas fitting on new scene creation

### DIFF
--- a/src/ui/dialogs/scenesettingsdialog.cpp
+++ b/src/ui/dialogs/scenesettingsdialog.cpp
@@ -29,6 +29,7 @@
 #include "appsupport.h"
 #include "Private/document.h"
 #include "Private/esettings.h"
+#include "../../app/GUI/canvaswindow.h"
 
 SceneSettingsDialog::SceneSettingsDialog(Canvas * const canvas,
                                          QWidget * const parent)
@@ -367,6 +368,11 @@ void SceneSettingsDialog::sNewSceneDialog(Document& document,
         const auto block = newCanvas->blockUndoRedo();
         dialog->applySettingsToCanvas(newCanvas);
         newCanvas->anim_setAbsFrame(newCanvas->getFrameRange().fMin);
+        // --- Fit to canvas = Ctrl + 0 when creating a new file. ---
+        const auto target = KeyFocusTarget::KFT_getCurrentTarget();
+        const auto cwTarget = dynamic_cast<CanvasWindow*>(target);
+        if (cwTarget) { cwTarget->fitCanvasToSize(); }
+        // -----------------------------------------------------------
         dialog->close();
         docPtr->actionFinished();
     });


### PR DESCRIPTION
Added “Fit to Canvas” (Ctrl + 0) function to automatically center and scale the artboard when creating a new scene.
-------------------------------------------------------------------------------------------------------------------------
<img width="1117" height="558" alt="2026-04-19 00_30_31-Window" src="https://github.com/user-attachments/assets/4a3fcd05-5fdb-4520-b451-30e611c6d375" />
When creating a new file (for example, 1220×1080), the artboard is not centered on the canvas, unlike the default 1920×1080 size, which initializes already centered.