### PR TITLE
Expressions: add $parent binding paths

### DIFF
--- a/src/app/GUI/Expressions/expressionhighlighter.cpp
+++ b/src/app/GUI/Expressions/expressionhighlighter.cpp
@@ -44,7 +44,10 @@ ExpressionHighlighter::ExpressionHighlighter(
     mErrorFormat.setForeground(Qt::red);
     mAssignFormat.setForeground(QColor(255, 128, 128));
 
-    const QString propPath = "([a-zA-Z0-9_\\.]+[a-zA-Z0-9_ \\.]*[a-zA-Z0-9_\\.]+)";
+    const QString propPath = "((?:\\$parent\\.)*"
+                             "[a-zA-Z0-9_\\.]+"
+                             "[a-zA-Z0-9_ \\.]*"
+                             "[a-zA-Z0-9_\\.]+)";
     mPropSetRegex = QRegularExpression("^\\s*"
                                             "([A-Za-z_][A-Za-z0-9_]*)"
                                        "\\s*=\\s*" + propPath);
@@ -62,6 +65,7 @@ ExpressionHighlighter::ExpressionHighlighter(
     const QStringList specs = {
         QStringLiteral("$value"),
         QStringLiteral("$frame"),
+        QStringLiteral("$parent"),
         QStringLiteral("$scene.fps"),
         QStringLiteral("$scene.width"),
         QStringLiteral("$scene.height"),

--- a/src/core/Animators/complexanimator.cpp
+++ b/src/core/Animators/complexanimator.cpp
@@ -28,6 +28,7 @@
 #include "Sound/esound.h"
 #include <QPainter>
 #include "Boxes/boundingbox.h"
+#include "Animators/transformanimator.h"
 
 ComplexAnimator::ComplexAnimator(const QString &name) :
     Animator(name) {
@@ -205,6 +206,32 @@ void ComplexAnimator::ca_updateDescendatKeyFrame(Key* key) {
 Property *ComplexAnimator::ca_findPropertyWithPathRec(
         const int id, const QStringList &path,
         QStringList * const completions) const {
+    if(id < path.count() && path.at(id) == QStringLiteral("$parent")) {
+        const auto currentBox = getFirstAncestor<BoundingBox>();
+        const auto findParentBox = [](const BoundingBox* const box) {
+            const auto parentTransform = box ? box->getParentTransform() : nullptr;
+            return parentTransform ?
+                        parentTransform->getFirstAncestor<BoundingBox>() : nullptr;
+        };
+        auto parentBox = findParentBox(currentBox);
+        int nextId = id + 1;
+        while(parentBox && nextId < path.count() &&
+              path.at(nextId) == QStringLiteral("$parent")) {
+            parentBox = findParentBox(parentBox);
+            ++nextId;
+        }
+        if(!parentBox) return nullptr;
+        if(nextId == path.count()) {
+            if(completions) {
+                parentBox->ca_findPropertyWithPath(
+                            0, QStringList() << QString(), completions);
+            }
+            return parentBox;
+        }
+        return parentBox->ca_findPropertyWithPath(
+                    nextId, path, completions);
+    }
+
     Property* found = nullptr;
     const ComplexAnimator* acestorIter = this;
     while(acestorIter && (completions || !found)) {

--- a/src/core/Boxes/boundingbox.cpp
+++ b/src/core/Boxes/boundingbox.cpp
@@ -476,6 +476,7 @@ void BoundingBox::setParentTransform(BasicTransformAnimator *parent) {
     if(parent == mParentTransform) return;
     mParentTransform = parent;
     mTransformAnimator->setParentTransformAnimator(mParentTransform);
+    emit prp_pathChanged();
 }
 
 void BoundingBox::afterTotalTransformChanged(const UpdateReason reason) {

--- a/src/core/Boxes/boundingbox.h
+++ b/src/core/Boxes/boundingbox.h
@@ -330,6 +330,8 @@ public:
 
     void clearParent();
     void setParentTransform(BasicTransformAnimator *parent);
+    BasicTransformAnimator* getParentTransform() const
+    { return mParentTransform; }
 
     bool isContainedIn(const QRectF &absRect) const;
 

--- a/src/core/Expressions/propertybinding.cpp
+++ b/src/core/Expressions/propertybinding.cpp
@@ -127,6 +127,8 @@ Property *PropertyBinding::sFindPropertyToBind(const QString& binding,
 
 void PropertyBinding::updateBindPath() {
     if(!mBindProperty || !mContext) return;
+    if(mPath == QStringLiteral("$parent") ||
+       mPath.startsWith(QStringLiteral("$parent."))) return;
     QStringList prntPath;
     mContext->prp_getFullPath(prntPath);
     QStringList srcPath;

--- a/src/core/Expressions/propertybindingparser.cpp
+++ b/src/core/Expressions/propertybindingparser.cpp
@@ -126,7 +126,8 @@ bool parseSceneRangeMin(const QString& exp, int& pos) {
 void parseBinding(const QString& exp, int& pos, QString& binding) {
     while(pos < exp.count()) {
         const auto& c = exp.at(pos++);
-        if(!c.isLetterOrNumber() && c != ' ' && c != '.' && c != '_') break;
+        if(!c.isLetterOrNumber() && c != ' ' && c != '.' &&
+           c != '_' && c != '$') break;
         binding.append(c);
     }
 }


### PR DESCRIPTION
As requested [here](https://github.com/orgs/friction2d/discussions/801), this PR adds a symbolic `$parent` path prefix to Friction expression bindings.

Expressions can now access properties from an object's transform parent without referencing that object by name.

## Usage

Access the direct parent's translation:

```js
// Bindings
parentX = $parent.transform.translation.x;

// Calculate
return parentX;
```

Access a grandparent by chaining `$parent`:

```js
// Bindings
grandParentRotation = $parent.$parent.transform.rotation;

// Calculate
return grandParentRotation;
```

Any number of parent levels can be requested:

```text
$parent
$parent.$parent
$parent.$parent.$parent
```

`$parent` must appear at the beginning of a property path.

## Parent resolution

`$parent` follows Friction's actual transform-parent relationship, rather than only the visual containment hierarchy.

This means it supports:

- The default transform inherited from the containing group.
- Explicit parenting to another object.
- Multiple parent levels through `$parent.$parent`.
- Reparenting after the expression has already been created.

If the requested parent does not exist, the binding is marked as invalid.

## Dynamic rebinding

Bindings beginning with `$parent` remain symbolic instead of being converted into object-name paths.

When an object's transform parent changes, Friction emits a logical path update and resolves the binding again. Expressions therefore follow the new parent automatically without needing to be reopened or edited.

## Dependency handling

Existing expression dependency and cycle validation remains active.

A binding through `$parent` is treated like any other property binding, so circular expression dependencies are rejected.

## Editor integration

The expression editor now provides:

- `$parent` syntax highlighting.
- `$parent` autocomplete.
- Property completion after `$parent`.
- Property completion through chained parent paths.

For example:

```text
$parent.transform.translation.x
$parent.$parent.transform.rotation
```

## Serialization

No EV or XEV format changes are required.

`$parent` paths are stored inside the existing expression binding string and resolved when the expression is loaded.

## Validation

Test builds:

- **Linux**: https://github.com/friction2d/friction/actions/runs/31089181129/artifacts/8963078252
- **Windows**: https://github.com/friction2d/friction/actions/runs/31089181155/artifacts/8963110673
- **macOS**: https://github.com/friction2d/friction/actions/runs/31089181596/artifacts/8963664759