### PR TITLE
UX: refactor Duplicate action

### DIFF
--- a/src/core/canvas.cpp
+++ b/src/core/canvas.cpp
@@ -1194,8 +1194,31 @@ void Canvas::splitAction()
 
 void Canvas::duplicateAction()
 {
-    copyAction();
-    pasteAction();
+    if (mSelectedBoxes.isEmpty()) { return; }
+
+    const auto originals = mSelectedBoxes.getList();
+    clearBoxesSelection();
+
+    for (auto* box : originals) {
+        if (!box) continue;
+
+        ContainerBox* targetContainer = box->getParentGroup();
+        if (!targetContainer) { targetContainer = mCurrentContainer; }
+
+        const int originalZIndex = box->getZIndex();
+        const QString originalName = box->prp_getName();
+
+        QList<BoundingBox*> singleList;
+        singleList.append(box);
+
+        const auto tempClipboard = enve::make_shared<BoxesClipboard>(singleList);
+        tempClipboard->pasteTo(targetContainer);
+
+        if (mLastSelectedBox && mLastSelectedBox != box) {
+            mLastSelectedBox->moveTo(originalZIndex);
+            mLastSelectedBox->prp_setName(originalName + " Copy");
+        }
+    }
 }
 
 void Canvas::selectAllAction()


### PR DESCRIPTION
Our existing duplicate action sucks, it just a plain copy/pasta. This PR fixes this, it does not overwrite the existing copy buffer and keep the parent (group) for each new box.


https://github.com/user-attachments/assets/5f3e0a5b-d494-406c-88fc-9124df45a81a

Fixes https://github.com/friction2d/friction/issues/754 (and possible other)