### PR TITLE
Workaround macOS fit to canvas size

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -499,6 +499,15 @@ void MainWindow::setupDocument()
         if (mTimeline) { mTimeline->stopPreview(); }
     });
 
+#ifdef Q_OS_MAC
+    // https://github.com/friction2d/friction/pull/736
+    connect(&mDocument, &Document::fitCanvasToSize, this, []() {
+        const auto target = KeyFocusTarget::KFT_getCurrentTarget();
+        const auto cwTarget = dynamic_cast<CanvasWindow*>(target);
+        if (cwTarget) { cwTarget->fitCanvasToSize(); }
+    });
+#endif
+
     // set defaults
     mDocument.setPath("");
     mDocument.fDrawPathManual = false;

--- a/src/core/Private/document.h
+++ b/src/core/Private/document.h
@@ -258,6 +258,9 @@ signals:
     void openApplyExpressionDialog(QrealAnimator* const target);
     void newVideo(const VideoBox::VideoSpecs specs);
     void currentPixelColor(const QColor &color);
+
+    // https://github.com/friction2d/friction/pull/736
+    void fitCanvasToSize();
 };
 
 #endif // DOCUMENT_H

--- a/src/ui/dialogs/scenesettingsdialog.cpp
+++ b/src/ui/dialogs/scenesettingsdialog.cpp
@@ -369,6 +369,10 @@ void SceneSettingsDialog::sNewSceneDialog(Document& document,
         newCanvas->anim_setAbsFrame(newCanvas->getFrameRange().fMin);
         dialog->close();
         docPtr->actionFinished();
+#ifdef Q_OS_MAC
+        // https://github.com/friction2d/friction/pull/736
+        emit docPtr->fitCanvasToSize();
+#endif
     });
 
     dialog->show();


### PR DESCRIPTION
Workaround another "magic" macOS bug that does not make sense.

I don't like doing this, but what are the alternatives?

Ref #736 